### PR TITLE
Integrate HTTP cache

### DIFF
--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "json_api_client", "1.0.2"
   spec.add_runtime_dependency "activesupport", "~> 4"
   spec.add_runtime_dependency "rack", "~> 1.6"
+  spec.add_runtime_dependency "faraday-http-cache", "1.3.0"
 end

--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -11,11 +11,11 @@ module FlexCommerceApi
         include_previewed = options.fetch :include_previewed, false
         @faraday = Faraday.new(site) do |builder|
           builder.request :json
-          builder.use :http_cache, cache_options(options)
           builder.use JsonApiClientExtension::SaveRequestBodyMiddleware
           builder.use JsonApiClientExtension::JsonFormatMiddleware
           builder.use JsonApiClientExtension::PreviewedRequestMiddleware if include_previewed
           builder.use JsonApiClient::Middleware::JsonRequest
+          builder.use :http_cache, cache_options(options)
           builder.use JsonApiClientExtension::StatusMiddleware
           builder.use JsonApiClient::Middleware::ParseJson
           builder.adapter *adapter_options
@@ -39,8 +39,10 @@ module FlexCommerceApi
           shared_cache: false,
           # use the Rails cache, if set, otherwise default to MemoryStore
           store: defined?(Rails) ? Rails.cache : nil,
-          # serialize the data using Oj
-          serializer: Oj
+          # serialize the data using Marshal
+          serializer: Marshal,
+          # use our configured logger
+          logger: FlexCommerceApi.logger
         }.merge(options.fetch(:http_cache, {}))
       end
     end

--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -1,4 +1,3 @@
-require 'oj'
 require 'faraday-http-cache'
 
 module FlexCommerceApi


### PR DESCRIPTION
This PR introduces the `faraday-http-cache` gem which provides a HTTP caching middleware.

There are no specs in the gem for this (not the easiest to test) but I have verified with my console.