### PR TITLE
Bug fix: Rails cache setup in HTTP cache

### DIFF
--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -37,7 +37,7 @@ module FlexCommerceApi
           # treats the cache like a client, not a proxy
           shared_cache: false,
           # use the Rails cache, if set, otherwise default to MemoryStore
-          store: defined?(Rails) ? Rails.cache : nil,
+          store: defined?(::Rails) ? ::Rails.cache : nil,
           # serialize the data using Marshal
           serializer: Marshal,
           # use our configured logger


### PR DESCRIPTION
Fixes `undefined method 'cache' for FlexCommerceApi::Rails:Module`