### PR TITLE
Add #cache_key method to models

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -120,6 +120,14 @@ module FlexCommerceApi
       end
     end
 
+    def cache_key
+      if respond_to?(:id) && respond_to?(:updated_at) && id && updated_at
+        [self.class.name, id, updated_at.to_datetime.utc.to_i.to_s].join("/")
+      else
+        raise NotImplementedError, "This model doesn't have an id/updated_at field, so requires custom #cache_key implementation"
+      end
+    end
+
     def method_missing(method, *args)
       if relationships and relationships.has_attribute?(method)
         super


### PR DESCRIPTION
This method helps Rails with clean caching, e.g.

```ruby
def show
  @menu = ::FlexCommerce::Menu.find("main-menu")
  fresh_when(@menu)
end
```

```erb
<% cache(@menu) do %>
  ...
<% end %>
```

It's defined on `FlexCommerce::ApiBase` which all the models inherit from, but only works if a given object has both an `id` and `updated_at` attribute, if either are missing a `NotImplementedError` will be raised and that model will have to manually define it's `cache_key` method.