### PR TITLE
Translate search filters that contain lte in addition to existing lt

### DIFF
--- a/app/services/param_to_shql.rb
+++ b/app/services/param_to_shql.rb
@@ -31,7 +31,7 @@ module FlexCommerce
       facet_filters = []
       @filter_param.each do |label,facet|
         facet_filter = []
-        if facet.keys.include?("gt") || facet.keys.include?("lt")
+        if (facet.keys & ['lt', 'lte', 'gt', 'gte']).any?
           range_filter =  range_param_to_shql(label, facet)
           facet_filter << range_filter if !(range_filter == "" || range_filter == nil)
         else

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
The gem currently translates filter params passwed from the Front End into SHQL to be sent to the API,  but it ignores *lte* and *gte*.

This PR changes the Flex Ruby Gem to build SHQL for lte and gte in the same way as lt and gt.

It will make it possible for the Front End to search price ranges up to and including the min and max.