### PR TITLE
Fix for when fastly errors are returned

### DIFF
--- a/lib/flex_commerce_api/error/internal_server.rb
+++ b/lib/flex_commerce_api/error/internal_server.rb
@@ -3,14 +3,15 @@ module FlexCommerceApi
     class InternalServer < Base
       def message
         body = response_env.fetch(:body, {errors: []})
-        error = body[:errors].first
-        if error
+        error = body.is_a?(::String) ? body : body[:errors].first
+        return "Internal server error" unless error.present?
+        if error.is_a?(::Enumerable)
           title = error.fetch(:title, "")
           detail = error.fetch(:detail, "")
           backtrace = error.fetch(:meta, {backtrace: []}).fetch(:backtrace)
           "Internal server error - #{title} #{detail} #{backtrace}"
         else
-          "Internal server error"
+          "Internal server error - #{error}"
         end
       end
 

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
   API_VERSION = "v1"
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
PR resolves - 

<img width="1132" alt="screen shot 2016-04-28 at 12 16 15" src="https://cloud.githubusercontent.com/assets/4486874/14888750/a8ccb6cc-0d53-11e6-98d3-f85769a74f82.png">

When there is a fastly error, the `body` is a `String`, which is causing the above F/E issue