### PR TITLE
Allow optional caching

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -83,8 +83,9 @@ module FlexCommerceApi
       def reconfigure options = {}
         self.site = FlexCommerceApi.config.api_base_url
         adapter_options = { adapter: FlexCommerceApi.config.adapter || :net_http }
+        http_cache_options = { http_cache: FlexCommerceApi.config.http_cache }
         self.connection_options.delete(:include_previewed)
-        self.connection_options = connection_options.merge(adapter_options).merge(options)
+        self.connection_options = connection_options.merge(adapter_options).merge(http_cache_options).merge(options)
         reload_connection_if_required
       end
 

--- a/lib/flex_commerce_api/config.rb
+++ b/lib/flex_commerce_api/config.rb
@@ -30,12 +30,13 @@ module FlexCommerceApi
     #  a later version of the API you must get a later version of the gem.
     # @!attribute order_test_mode
     #  The order test mode.This config determines if orders are processed as test or real orders
-    attr_accessor :flex_root_url, :flex_api_key, :flex_account, :logger, :adapter, :order_test_mode
+    attr_accessor :flex_root_url, :flex_api_key, :flex_account, :logger, :adapter, :order_test_mode, :http_cache
     attr_reader :api_version
 
     def initialize
       @api_version = API_VERSION
       self.order_test_mode = false
+      self.http_cache = {}
     end
 
     # The api base URL

--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -14,7 +14,10 @@ module FlexCommerceApi
           builder.use JsonApiClientExtension::JsonFormatMiddleware
           builder.use JsonApiClientExtension::PreviewedRequestMiddleware if include_previewed
           builder.use JsonApiClient::Middleware::JsonRequest
-          builder.use :http_cache, cache_options(options)
+          # disable the cache when HTTP cache is set to false
+          unless false == options[:http_cache]
+            builder.use :http_cache, cache_options(options)
+          end
           builder.use JsonApiClientExtension::StatusMiddleware
           builder.use JsonApiClient::Middleware::ParseJson
           builder.adapter *adapter_options

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
This allows us to configure the gem to disable the HTTP cache, simply by setting it's option to false, e.g.

```ruby
FlexCommerceApi.config do |config|
  config.http_cache = false
end
```