### PR TITLE
Feature/update meta attribute getter

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -111,7 +111,10 @@ module FlexCommerceApi
     end
 
     def meta_attribute(key)
-      attributes[:meta_attributes][key][:value] rescue nil
+      case attributes[:meta_attributes][key][:data_type]
+      when "related-files", "related-products" then self.send(key)
+      else attributes[:meta_attributes][key][:value] rescue nil
+      end
     end
 
     def template_attribute(key)

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -18,6 +18,7 @@ module FlexCommerceApi
   #
   class ApiBase < JsonApiClient::Resource
     PRIVATE_ATTRIBUTES = %w(id type relationships links meta)
+    RELATED_META_RESOURCES = %w(related-categories related-static_pages related-resources related-files related-products)
     # set the api base url in an abstract base class
     self.paginator = JsonApiClientExtension::Paginator
     self.requestor_class = JsonApiClientExtension::Requestor
@@ -111,16 +112,18 @@ module FlexCommerceApi
     end
 
     def meta_attribute(key)
-      case attributes[:meta_attributes][key][:data_type]
-      when "related-files", "related-products" then self.send(key)
-      else attributes[:meta_attributes][key][:value] rescue nil
+      if RELATED_META_RESOURCES.include?(attributes[:meta_attributes][key][:data_type])
+        self.send(key) rescue nil
+      else
+        attributes[:meta_attributes][key][:value] rescue nil
       end
     end
 
     def template_attribute(key)
-      case attributes[:template_attributes][key][:data_type]
-      when "related-files", "related-products" then self.send("template_#{key}")
-      else attributes[:template_attributes][key][:value] rescue nil
+      if RELATED_META_RESOURCES.include?(attributes[:template_attributes][key][:data_type])
+        self.send("template_#{key}") rescue nil
+      else
+        attributes[:template_attributes][key][:value] rescue nil
       end
     end
 

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.14"
+  VERSION = "0.4.15"
   API_VERSION = "v1"
 end

--- a/spec/integration/meta_attributes_spec.rb
+++ b/spec/integration/meta_attributes_spec.rb
@@ -41,5 +41,91 @@ RSpec.describe "url encoding on any model" do
     it 'does not allow get by direct reference to attribute' do
       expect(result.foo).to eq nil
     end
+
+    context 'with meta data of type related-products' do
+      let!(:example_data) do
+        {
+          data: {
+            id: "1",
+            type: "meta_attributable_class",
+            attributes: {
+              meta_attributes: { related_products: { value: [1], data_type: "related-products" } }
+            },
+            relationships: {
+              related_products: {
+                data: [
+                  {
+                    id: "1",
+                    type: "meta_attributable_class"
+                  }
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              id: "1",
+              type: "meta_attributable_class",
+              attributes: {
+                name: "Product image 1"
+              }
+            }
+          ]
+        }
+      end
+
+      let(:result) { subject_class.find("slug:my_slug") }
+
+      it 'allows get by meta attribute method' do
+        expect(result.meta_attribute(:related_products).map(&:id)).to eq ["1"]
+      end
+
+      it 'does allows get by direct reference to attribute' do
+        expect(result.meta_attribute(:related_products).map(&:id)).to eq ["1"]
+      end
+    end
+
+    context 'with meta data of type related-files' do
+      let!(:example_data) do
+        {
+          data: {
+            id: "1",
+            type: "meta_attributable_class",
+            attributes: {
+                meta_attributes: { related_files: { value: [1], data_type: "related-files" } }
+            },
+            relationships: {
+              related_files: {
+                data: [
+                  {
+                    id: "1",
+                    type: "meta_attributable_class"
+                  }
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              id: "1",
+              type: "meta_attributable_class",
+              attributes: {
+                name: "asset file 1"
+              }
+            }
+          ]
+        }
+      end
+
+      let(:result) { subject_class.find("slug:my_slug") }
+
+      it 'allows get by meta attribute method' do
+        expect(result.meta_attribute(:related_files).map(&:id)).to eq ["1"]
+      end
+
+      it 'does allows get by direct reference to attribute' do
+        expect(result.meta_attribute(:related_files).map(&:id)).to eq ["1"]
+      end
+    end
   end
 end


### PR DESCRIPTION
PR adds the ability to retrieve related resources contained within meta_attributes, eg.

```ruby
resource.meta_attribute(:related_files)
```