### PR TITLE
Hotfix/3826 sellable flag lag

### DIFF
--- a/lib/flex_commerce_api/json_api_client_extension/builder.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/builder.rb
@@ -5,8 +5,9 @@ module FlexCommerceApi
         super
         @temp_search_criteria = nil
       end
-      def temp_search(options = {}, available_to_browse_only=true)
-        @temp_search_criteria = options
+      def temp_search(options = {})
+        available_to_browse_only = options.delete(:available_to_browse_only) { true }
+        @temp_search_criteria    = options
         apply_available_to_browse_filter if available_to_browse_only
         self
       end

--- a/lib/flex_commerce_api/json_api_client_extension/builder.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/builder.rb
@@ -32,7 +32,7 @@ module FlexCommerceApi
       end
 
       def search_filters
-        search_filters = @temp_search_criteria[:filter]
+        search_filters = @temp_search_criteria[:filter] || {}
         search_filters.is_a?(String) ? JSON.parse(search_filters) : search_filters
       end
     end

--- a/lib/flex_commerce_api/json_api_client_extension/builder.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/builder.rb
@@ -5,8 +5,9 @@ module FlexCommerceApi
         super
         @temp_search_criteria = nil
       end
-      def temp_search(options = {})
+      def temp_search(options = {}, available_to_browse_only=true)
         @temp_search_criteria = options
+        apply_available_to_browse_filter if available_to_browse_only
         self
       end
 
@@ -22,6 +23,17 @@ module FlexCommerceApi
         else
           klass.requestor.custom(:search, { request_method: :get }, params.merge(filter: @temp_search_criteria))
         end
+      end
+
+      private
+
+      def apply_available_to_browse_filter
+        @temp_search_criteria[:filter]=search_filters.merge({ "available_to_browse" => { "eq" => true } })
+      end
+
+      def search_filters
+        search_filters = @temp_search_criteria[:filter]
+        search_filters.is_a?(String) ? JSON.parse(search_filters) : search_filters
       end
     end
   end

--- a/spec/integration/product_spec.rb
+++ b/spec/integration/product_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe FlexCommerce::Product do
       #  than the paginated version.
       let(:stubbed_url) do
         URI.parse(current_page.present? ? "#{collection_url}/pages/#{current_page}.json_api" : "#{collection_url}.json_api").tap do |u|
-          u.query = { filter: search_criteria }.to_query
+          u.query = { filter: search_criteria.merge( {filter: { "available_to_browse" => { "eq" => true } }} ) }.to_query
         end.to_s
       end
 

--- a/spec/integration/product_spec.rb
+++ b/spec/integration/product_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe FlexCommerce::Product do
 
       # The subject for all examples - using pagination as this is expected normally
       subject do
-        subject_class.temp_search({ query: "Shirt", fields: "description,reference,slug" }, available_to_browse_only).paginate(page: current_page).all
+        subject_class.temp_search( query: "Shirt", fields: "description,reference,slug", available_to_browse_only: available_to_browse_only ).paginate(page: current_page).all
       end
       let(:expected_body) do
         {

--- a/spec/integration/product_spec.rb
+++ b/spec/integration/product_spec.rb
@@ -65,18 +65,19 @@ RSpec.describe FlexCommerce::Product do
     # temp_search is temporary until we defined a standard for searching all collections
     # when the real search is implemented, this spec must be enhanced - it checks for basics at the moment
     context "using temp_search" do
+
       # Calculates the stubbed_url depending on if current_page is nil or not
       #  If current page is nil, then it is expected that the test will fetch its data from the collection_url rather
       #  than the paginated version.
       let(:stubbed_url) do
         URI.parse(current_page.present? ? "#{collection_url}/pages/#{current_page}.json_api" : "#{collection_url}.json_api").tap do |u|
-          u.query = { filter: search_criteria.merge( {filter: { "available_to_browse" => { "eq" => true } }} ) }.to_query
+          u.query = { filter: search_criteria }.to_query
         end.to_s
       end
 
       # The subject for all examples - using pagination as this is expected normally
       subject do
-        subject_class.temp_search(query: "Shirt", fields: "description,reference,slug").paginate(page: current_page).all
+        subject_class.temp_search({ query: "Shirt", fields: "description,reference,slug" }, available_to_browse_only).paginate(page: current_page).all
       end
       let(:expected_body) do
         {
@@ -88,12 +89,29 @@ RSpec.describe FlexCommerce::Product do
       # Easy access to the collection URL
       let(:collection_url) { "#{api_root}/products/search" }
       let(:quantity) { 50 }
-      let(:search_criteria) { { query: "Shirt", fields: "description,reference,slug" } }
+
       let!(:stub) do
         stub_request(:get, stubbed_url).with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_json, status: response_status, headers: default_headers
       end
 
-      it_should_behave_like "a collection of anything"
+      context 'requesting only products that are available_to_browse' do
+
+        let(:available_to_browse_only) { true }
+        # NOTE test here is that the available_to_browse flag is added as a fitler
+        let(:search_criteria) { { filter: { "available_to_browse" => { "eq" => true } }, query: "Shirt", fields: "description,reference,slug" } }
+
+        it_should_behave_like "a collection of anything"
+      end
+
+      context 'requesting any products (even those that are NOT available_to_browse)' do
+
+        let(:available_to_browse_only) { false }
+        # NOTE test here is that the available_to_browse filter is absent
+        let(:search_criteria) { { query: "Shirt", fields: "description,reference,slug" } }
+
+        it_should_behave_like "a collection of anything"
+      end
+
     end
     context "fetching from a known category tree and category" do
       let(:expected_list_quantity) { 25 }


### PR DESCRIPTION
### Overview

Related GitHub issue: #https://github.com/shiftcommerce/flex-platform/issues/3826

Adds a default available_to_browse filter when performing searches.
This prevents products that are not in a sellable state from appearing in search results by default.

### QA

Create products that are in a sellable state.
Perform a search for said products to verify they can be found in search.
Change the state of those products so they are no longer in a sellable state, eg change the sellable flag to false.