### PR TITLE
Menu model to exclude "path" in path calculation - as path is an attr…

### DIFF
--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -30,7 +30,7 @@ module FlexCommerce
     has_many :menu_items
     # This model has a path attribute so path can no longer be used to modify the path
     def self.path(params = nil, record = nil)
-      super(params.except("path"), record)
+      super(params.nil? ? nil : params.except("path"), record)
     end
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -28,5 +28,9 @@ module FlexCommerce
   #
   class Menu < FlexCommerceApi::ApiBase
     has_many :menu_items
+    # This model has a path attribute so path can no longer be used to modify the path
+    def self.path(params = nil, record = nil)
+      super(params.except("path"), record)
+    end
   end
 end


### PR DESCRIPTION
Menu model to exclude "path" in path calculation - as path is an attribute of a menu but it is also a reserved word for the gems path calculation