### PR TITLE
When a Cart is created, optionally set test:true

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -89,7 +89,7 @@ module FlexCommerce
       end
     end
 
-    def self.create()
+    def self.create(*args)
       if FlexCommerceApi.config.order_test_mode
         super({test: true})
       else

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -89,20 +89,18 @@ module FlexCommerce
       end
     end
 
-    def self.create(attributes)
-      super(attributes.merge(extra_attributes))
+    def self.create()
+      if FlexCommerceApi.config.order_test_mode
+        super({test: true})
+      else
+        super
+      end
     end
 
     private
 
     def stock_levels
       StockLevel.where(skus: line_items.map { |li| li.item.sku }.join(",")).all
-    end
-
-    def self.extra_attributes
-      extras = {}
-      extras.merge!(test: true) if FlexCommerceApi.config.order_test_mode
-      extras
     end
 
 

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -104,5 +104,5 @@ module FlexCommerce
     end
 
 
-  end
+  end 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -26,7 +26,7 @@ module FlexCommerce
 
   end
 
-  def self.create(attributes)
+  def self.create(attributes = {})
     super(attributes.merge(extra_attributes))
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -26,4 +26,13 @@ module FlexCommerce
 
   end
 
+  def self.create(attributes)
+    super(attributes.merge(extra_attributes))
+  end
+
+  def self.extra_attributes
+    extras = {}
+    extras.merge!(test: true) if FlexCommerceApi.config.order_test_mode
+    extras
+  end
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.20"
+  VERSION = "0.4.21"
   API_VERSION = "v1"
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.21"
+  VERSION = "0.4.22"
   API_VERSION = "v1"
 end

--- a/spec/integration/order_spec.rb
+++ b/spec/integration/order_spec.rb
@@ -13,31 +13,6 @@ RSpec.describe FlexCommerce::Order, focus: true do
 
     let(:write_headers) { { "Accept" => "application/vnd.api+json", "Content-Type" => "application/vnd.api+json" } }
 
-    describe "when config order test mode is true" do
-
-      before :each do
-
-        FlexCommerceApi.config.order_test_mode = true
-
-        stub_request(:post, "#{api_root}/orders.json_api").with(headers: write_headers).to_return do |request|
-          expect(Oj.load(request.body).with_indifferent_access).to include(data: hash_including(attributes: hash_including(test: true)))
-          {
-              body: {data: {attributes: {test: true}}}.to_json,
-              status: 201,
-              headers: write_headers
-          }
-        end
-
-      end
-
-      subject { described_class.create(attributes_for(:order)) }
-
-      it "includes test attribute on create" do
-        expect(subject.test).to eq(true)
-      end
-
-    end
-
     describe "when config order test mode is false" do
 
       before :each do


### PR DESCRIPTION
This used to happen when an Order was created, but the code was never called.

So now as soon as a Cart is created, it optionally gets test:true, depending on the setting from the config.
This is passed on to the order when it is created.