### PR TITLE
The redirect api model is now simplified to no longer use custom

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -7,11 +7,8 @@ module FlexCommerce
   #
   class Redirect < FlexCommerceApi::ApiBase
 
-    # abstraction to ensure redirects can be loaded easily
-    collection_endpoint :matches, request_method: :get
-
     def self.find_by_resource(source_type: nil, source_slug: nil, source_path: )
-      matches(filter: { source_type: source_type, source_slug: source_slug, source_path: source_path }).first
+      where({type_slug_path: { source_type: source_type, source_slug: source_slug, source_path: source_path }}).first
     end
   end
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.24"
+  VERSION = "0.4.25"
   API_VERSION = "v1"
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.4.25"
+  VERSION = "0.5.0"
   API_VERSION = "v1"
 end

--- a/spec/integration/redirect_spec.rb
+++ b/spec/integration/redirect_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FlexCommerce::Redirect do
     end
 
     it "should load a single Redirect when passing valid params" do
-      stub_request(:get, /redirects\/matches.json_api/).with(headers: { Accept: 'application/vnd.api+json' }).to_return({
+      stub_request(:get, /redirects.json_api/).with(headers: { Accept: 'application/vnd.api+json' }, query: hash_including(filter: anything)).to_return({
         body: File.read("./spec/fixtures/redirects/multiple.json"),
         status: 200,
         headers: default_headers


### PR DESCRIPTION
The redirect api model is now simplified to no longer use custom endpoint (as it is a filter)

This is a breaking change and will only work with latest API.  