### PR TITLE
return customer_account instance with error in case of invalid password reset token

### DIFF
--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
### Overview

Related GitHub issue: #4236 - quick workaround to return customer_account instance with errors in case of invalid password reset token. As agreed in ticket, further PRs will be created to refactor gem and api for proper handling.

### QA
Check scenario described in #4236