### PR TITLE
Hotfix/json api included data

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -12,11 +12,12 @@ require "flex_commerce_api/json_api_client_extension/previewed_request_middlewar
 require "flex_commerce_api/json_api_client_extension/has_many_association_proxy"
 require "flex_commerce_api/json_api_client_extension/builder"
 require "flex_commerce_api/json_api_client_extension/flexible_connection"
+require "flex_commerce_api/json_api_client_extension/resource"
 module FlexCommerceApi
   #
   # Base class for all flex commerce models
   #
-  class ApiBase < JsonApiClient::Resource
+  class ApiBase < ::FlexCommerceApi::JsonApiClientExtension::Resource
     PRIVATE_ATTRIBUTES = %w(id type relationships links meta)
     RELATED_META_RESOURCES = %w(related-categories related-static_pages related-resources related-files related-products)
     # set the api base url in an abstract base class

--- a/lib/flex_commerce_api/json_api_client_extension/resource.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/resource.rb
@@ -1,0 +1,42 @@
+require "json_api_client/resource"
+module FlexCommerceApi
+  module JsonApiClientExtension
+    class Resource < JsonApiClient::Resource
+      def method_missing(method, *args)
+        association = association_for(method)
+
+        return super unless association || (relationships && relationships.has_attribute?(method))
+
+        return nil unless relationship_definitions = relationships[method]
+
+        # look in included data
+        if relationship_definitions.key?("data")
+          return last_result_set.included.data_for(method, relationship_definitions) || last_result_set.find do |resource|
+            data = relationship_definitions["data"]
+            if data.is_a?(Array)
+              data.map do |link_def|
+                find_record_for(link_def)
+              end
+            elsif data.nil?
+              nil
+            else
+              find_record_for(data)
+            end
+          end
+        end
+
+        if association = association_for(method)
+          # look for a defined relationship url
+          if relationship_definitions["links"] && url = relationship_definitions["links"]["related"]
+            return association.data(url)
+          end
+        end
+        nil
+      end
+
+      def find_record_for(link_def)
+        last_result_set.find {|resource| resource.attributes["id"] == link_def["id"] && resource.attributes["type"] == link_def["type"]}
+      end
+    end
+  end
+end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
With this PR - if you have a relationship which specifies "data" as an ID and TYPE - instead of looking in just included data, it also looks in the top level data as JR quite rightly does not duplicate data that is already in the data section to the included section.