### PR TITLE
Capture surrogate keys and pass them to a front-end application.

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -9,6 +9,7 @@ require "flex_commerce_api/json_api_client_extension/logging_middleware"
 require "flex_commerce_api/json_api_client_extension/status_middleware"
 require "flex_commerce_api/json_api_client_extension/json_format_middleware"
 require "flex_commerce_api/json_api_client_extension/previewed_request_middleware"
+require "flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware"
 require "flex_commerce_api/json_api_client_extension/has_many_association_proxy"
 require "flex_commerce_api/json_api_client_extension/builder"
 require "flex_commerce_api/json_api_client_extension/flexible_connection"
@@ -74,6 +75,12 @@ module FlexCommerceApi
 
       def path(params = nil, record = nil)
         super(params)
+      end
+
+      def capture_surrogate_keys
+        Thread.current[:shift_surrogate_keys] = nil
+        yield
+        Thread.current[:shift_surrogate_keys].uniq.join(' ')
       end
 
       def reconfigure_all options = {}

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -80,7 +80,8 @@ module FlexCommerceApi
       def capture_surrogate_keys
         Thread.current[:shift_surrogate_keys] = []
         yield
-        results = Thread.current[:shift_surrogate_keys].uniq.join(' ')
+        Thread.current[:shift_surrogate_keys].uniq!
+        results = Thread.current[:shift_surrogate_keys].join(' ')
         Thread.current[:shift_surrogate_keys] = nil
         results
       end

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -80,7 +80,7 @@ module FlexCommerceApi
       def capture_surrogate_keys
         Thread.current[:shift_surrogate_keys] = nil
         yield
-        Thread.current[:shift_surrogate_keys].uniq.join(' ')
+        Thread.current[:shift_surrogate_keys].uniq.join(' ') if Thread.current[:shift_surrogate_keys]
       end
 
       def reconfigure_all options = {}

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -78,9 +78,11 @@ module FlexCommerceApi
       end
 
       def capture_surrogate_keys
-        Thread.current[:shift_surrogate_keys] = nil
+        Thread.current[:shift_surrogate_keys] = []
         yield
-        Thread.current[:shift_surrogate_keys].uniq.join(' ') if Thread.current[:shift_surrogate_keys]
+        results = Thread.current[:shift_surrogate_keys].uniq.join(' ')
+        Thread.current[:shift_surrogate_keys] = nil
+        results
       end
 
       def reconfigure_all options = {}

--- a/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
@@ -6,10 +6,8 @@ module FlexCommerceApi
         @app.call(environment).on_complete do |env|
           surrogate_keys = env.response_headers['external-surrogate-key'].split(' ') if env.response_headers['external-surrogate-key']
 
-          if surrogate_keys
-            unless Thread.current[:shift_surrogate_keys].nil?
-              Thread.current[:shift_surrogate_keys].concat(surrogate_keys)
-            end
+          if surrogate_keys && Thread.current[:shift_surrogate_keys]
+            Thread.current[:shift_surrogate_keys].concat(surrogate_keys)
           end
         end
       end

--- a/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
@@ -7,10 +7,8 @@ module FlexCommerceApi
           surrogate_keys = env.response_headers['external-surrogate-key'].split(' ') if env.response_headers['external-surrogate-key']
 
           if surrogate_keys
-            if Thread.current[:shift_surrogate_keys].nil?
-              Thread.current[:shift_surrogate_keys] = surrogate_keys
-            else
-              Thread.current[:shift_surrogate_keys] = Thread.current[:shift_surrogate_keys].push(*surrogate_keys)
+            unless Thread.current[:shift_surrogate_keys].nil?
+              Thread.current[:shift_surrogate_keys].concat(surrogate_keys)
             end
           end
         end

--- a/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
@@ -1,4 +1,4 @@
-# Adds surrogate keys header to all requests to Flex API.
+# Captures surrogate keys headers and collects them for passing to the client.
 module FlexCommerceApi
   module JsonApiClientExtension
     class CaptureSurrogateKeysMiddleware < ::Faraday::Middleware

--- a/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/capture_surrogate_keys_middleware.rb
@@ -1,0 +1,20 @@
+# Adds surrogate keys header to all requests to Flex API.
+module FlexCommerceApi
+  module JsonApiClientExtension
+    class CaptureSurrogateKeysMiddleware < ::Faraday::Middleware
+      def call(environment)
+        @app.call(environment).on_complete do |env|
+          surrogate_keys = env.response_headers['external-surrogate-key'].split(' ') if env.response_headers['external-surrogate-key']
+
+          if surrogate_keys
+            if Thread.current[:shift_surrogate_keys].nil?
+              Thread.current[:shift_surrogate_keys] = surrogate_keys
+            else
+              Thread.current[:shift_surrogate_keys] = Thread.current[:shift_surrogate_keys].push(*surrogate_keys)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -19,6 +19,7 @@ module FlexCommerceApi
             builder.use :http_cache, cache_options(options)
           end
           builder.use JsonApiClientExtension::StatusMiddleware
+          builder.use JsonApiClientExtension::CaptureSurrogateKeysMiddleware
           builder.use JsonApiClient::Middleware::ParseJson
           builder.adapter *adapter_options
           builder.use JsonApiClientExtension::LoggingMiddleware unless FlexCommerceApi.logger.nil?

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
   API_VERSION = "v1"
 end

--- a/spec/integration/capture_surrogate_keys_spec.rb
+++ b/spec/integration/capture_surrogate_keys_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "flex_commerce_api/api_base"
+require "uri"
+
+RSpec.describe "capturing surrogate keys" do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) do
+    TempClass = Class.new(FlexCommerceApi::ApiBase) do
+    end
+  end
+
+  let(:empty_data) do
+    {
+      id: "1",
+      type: "base",
+      data: {}
+    }
+  end
+
+  it "should capture surrogate keys from a single request" do
+    headers = { "Content-Type": "application/json", "external-surrogate-key": "key1 key2" }
+
+    stub_request(:get, /\/temp_classes\/test\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers, status: 200 }
+    end
+
+    keys = FlexCommerceApi::ApiBase.capture_surrogate_keys do
+      subject_class.find('test')
+    end
+
+    expect(keys).to eq('key1 key2')
+  end
+
+  it "should combine surrogate keys from multiple requests" do
+    headers_one = { "Content-Type": "application/json", "external-surrogate-key": "key1 key2" }
+    headers_two = { "Content-Type": "application/json", "external-surrogate-key": "key3 key4" }
+
+    stub_request(:get, /\/temp_classes\/test\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers_one, status: 200 }
+    end
+
+    stub_request(:get, /\/temp_classes\/test2\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers_two, status: 200 }
+    end
+
+    keys = FlexCommerceApi::ApiBase.capture_surrogate_keys do
+      subject_class.find('test')
+      subject_class.find('test2')
+    end
+
+    expect(keys).to eq('key1 key2 key3 key4')
+  end
+
+  it "should ensure duplicate surrogate keys are removed" do
+    headers_one = { "Content-Type": "application/json", "external-surrogate-key": "key1 key2" }
+    headers_two = { "Content-Type": "application/json", "external-surrogate-key": "key2 key3" }
+
+    stub_request(:get, /\/temp_classes\/test\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers_one, status: 200 }
+    end
+
+    stub_request(:get, /\/temp_classes\/test2\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers_two, status: 200 }
+    end
+
+    keys = FlexCommerceApi::ApiBase.capture_surrogate_keys do
+      subject_class.find('test')
+      subject_class.find('test2')
+    end
+
+    expect(keys).to eq('key1 key2 key3')
+  end
+
+  it "should allow blank surrogate keys" do
+    headers = { "Content-Type": "application/json" }
+
+    stub_request(:get, /\/temp_classes\/test\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers, status: 200 }
+    end
+
+    keys = FlexCommerceApi::ApiBase.capture_surrogate_keys do
+      subject_class.find('test')
+    end
+
+    expect(keys).to eq(nil)
+  end
+end

--- a/spec/integration/capture_surrogate_keys_spec.rb
+++ b/spec/integration/capture_surrogate_keys_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe "capturing surrogate keys" do
       subject_class.find('test')
     end
 
-    expect(keys).to eq(nil)
+    expect(keys).to eq('')
+  end
+
+  it "should ensure surrogate keys are cleared between requests" do
+    headers = { "Content-Type": "application/json", "external-surrogate-key": "key1 key2" }
+
+    stub_request(:get, /\/temp_classes\/test\.json_api$/).to_return do |req|
+      { body: empty_data.to_json, headers: headers, status: 200 }
+    end
+
+    Thread.current[:shift_surrogate_keys] = nil
+    subject_class.find('test')
+    expect(Thread.current[:shift_surrogate_keys]).to eq(nil)
   end
 end


### PR DESCRIPTION
This PR introduces a middleware to capture Fastly surrogate keys, as supplied to the server, and store them for passing onto a client. We use this so that we can output Matalan pages with these surrogate keys to assist in Fastly caching, as described in https://github.com/shiftcommerce/matalan-rails-site/issues/633.