### PR TITLE
Use new endpoint for customer_account password recovery

### DIFF
--- a/app/models/password_recovery.rb
+++ b/app/models/password_recovery.rb
@@ -1,0 +1,20 @@
+require "flex_commerce_api/api_base"
+module FlexCommerce
+  #
+  # A flex commerce Password Recovery model
+  #
+  # This model provides access to the flex commerce customer account password recovery functionality.
+  # It is used much like an active record model.
+
+  class PasswordRecovery < FlexCommerceApi::ApiBase
+    belongs_to :customer_account, class_name: "::FlexCommerce::CustomerAccount"
+
+    def self.path(params, *args)
+      # Since it is singletone resource, use singular name in path and remove id
+      params.delete(:id) if params.key?(:id)
+      path = super.gsub(table_name, resource_name)
+      params.delete(:customer_account_id) if params.key?(:customer_account_id)
+      path
+    end
+  end
+end

--- a/app/models/password_recovery.rb
+++ b/app/models/password_recovery.rb
@@ -11,9 +11,9 @@ module FlexCommerce
 
     def self.path(params, *args)
       # Since it is singletone resource, use singular name in path and remove id
-      params.delete(:id) if params.key?(:id)
+      params.delete(:id)
       path = super.gsub(table_name, resource_name)
-      params.delete(:customer_account_id) if params.key?(:customer_account_id)
+      params.delete(:customer_account_id)
       path
     end
   end

--- a/lib/flex_commerce.rb
+++ b/lib/flex_commerce.rb
@@ -56,6 +56,7 @@ module FlexCommerce
   autoload :DataStoreRecord, File.join(gem_root, "app", "models", "data_store_record")
   autoload :DataStoreType, File.join(gem_root, "app", "models", "data_store_type")
   autoload :Note, File.join(gem_root, "app", "models", "note")
+  autoload :PasswordRecovery, File.join(gem_root, "app", "models", "password_recovery")
 
   # Services
   autoload :ParamToShql, File.join(gem_root, "app", "services", "param_to_shql")

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
   API_VERSION = "v1"
 end

--- a/spec/factories/password_recovery.rb
+++ b/spec/factories/password_recovery.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  klass = Struct.new(:token_present, :token_expired)
+  factory :password_recovery, class: klass do
+    token_present { [true, false].sample}
+    token_expired { [true, false].sample}
+
+    factory :password_recovery_with_valid_token do
+      token_present true
+      token_expired false
+    end
+
+    factory :password_recovery_with_used_token do
+      token_present false
+      token_expired true
+    end
+  end
+end


### PR DESCRIPTION
### Overview
Related to ticket #4261. Introduced new `PasswordRecovery` model which is working with new api endpoint. It is returned in 'included' section of CustomerAccount and provides token status (present?, expired?) and can be used by F/E to notify user about used/expired token and redirect him to request password recovery page.

NOTE: F/E need to be updated to use new model, example is provided in reference app.