### PR TITLE
adding 'find_by_token' method to customer_account

### DIFF
--- a/app/models/customer_account.rb
+++ b/app/models/customer_account.rb
@@ -65,6 +65,14 @@ module FlexCommerce
       nil
     end
 
+    # Find customer account by password reset token provided in email's link
+    # Used in reset password scenario
+    def self.find_by_token(token)
+      requestor.custom("token:#{token}", {request_method: :get}, {}).first
+    rescue ::FlexCommerceApi::Error::NotFound
+      nil
+    end
+
     def generate_token(attributes)
       ::FlexCommerce::PasswordRecovery.create(attributes.merge(customer_account_id: id))
     end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
### Overview

Related GitHub issue: #4416. Enhance ruby gem by adding `find_by_token' method for customer_accounts to retrieve customer by password reset token. It is used in scenario when customer requested reset password multiple times and uses link with token from not last email. In this case customer is redirected to page to request reset password again.
