### PR TITLE
Feature/artf5168550 order container coupon relationship issues

### DIFF
--- a/app/models/container_coupon.rb
+++ b/app/models/container_coupon.rb
@@ -6,6 +6,7 @@ module FlexCommerce
   #
   class ContainerCoupon < FlexCommerceApi::ApiBase
     has_one :promotion, class_name: "FlexCommerce::Promotion"
+    belongs_to :cart, class_name: "FlexCommerce::Cart"
 
   end
 end

--- a/app/models/container_coupon.rb
+++ b/app/models/container_coupon.rb
@@ -6,7 +6,7 @@ module FlexCommerce
   #
   class ContainerCoupon < FlexCommerceApi::ApiBase
     has_one :promotion, class_name: "FlexCommerce::Promotion"
-    belongs_to :cart, class_name: "FlexCommerce::Cart"
+    belongs_to :order, class_name: "FlexCommerce::Order"
 
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,7 @@ module FlexCommerce
     has_many :transactions, class_name: "::FlexCommerce::OrderTransaction"
     has_many :line_items, class_name: "::FlexCommerce::LineItem"
     has_many :coupons, class_name: "::FlexCommerce::Coupon"
+    has_many :coupons, class_name: "::FlexCommerce::ContainerCoupon"
     has_one :shipping_promotion, class_name: "::FlexCommerce::Promotion"
     has_one :shipping_address, class_name: "::FlexCommerce::Address"
     has_one :billing_address, class_name: "::FlexCommerce::Address"

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,7 +11,6 @@ module FlexCommerce
   class Order < FlexCommerceApi::ApiBase
     has_many :transactions, class_name: "::FlexCommerce::OrderTransaction"
     has_many :line_items, class_name: "::FlexCommerce::LineItem"
-    has_many :coupons, class_name: "::FlexCommerce::Coupon"
     has_many :coupons, class_name: "::FlexCommerce::ContainerCoupon"
     has_one :shipping_promotion, class_name: "::FlexCommerce::Promotion"
     has_one :shipping_address, class_name: "::FlexCommerce::Address"

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.10'
+  VERSION = '0.6.11'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
PR resolves the following issue -

<img width="660" alt="screen shot 2016-09-27 at 09 04 31" src="https://cloud.githubusercontent.com/assets/4486874/18865105/7eae118c-8491-11e6-8ddb-fe0c51902e9d.png">
*************
<img width="753" alt="screen shot 2016-09-27 at 08 39 13" src="https://cloud.githubusercontent.com/assets/4486874/18865086/5c6a4f96-8491-11e6-9ccb-ecbe3671cb95.png">
*************
It adds `Order/ContainerCoupon` association. 

Tested locally- 
```gem "flex_commerce_api", git: 'https://github.com/shiftcommerce/flex-ruby-gem.git', branch: 'feature/artf5168550_order_container_coupon_relationship_issues'```

