### PR TITLE
Hotfix/included data bug

### DIFF
--- a/lib/flex_commerce_api/json_api_client_extension/included_data.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/included_data.rb
@@ -1,0 +1,13 @@
+module FlexCommerce
+  module JsonApiClientExtension
+    class IncludedData < ::JsonApiClient::IncludedData
+      private
+
+      # should return a resource record of some type for this linked document
+      def record_for(link_def)
+        return nil unless data.key?(link_def["type"])
+        data[link_def["type"]][link_def["id"]]
+      end
+    end
+  end
+end

--- a/lib/flex_commerce_api/json_api_client_extension/parsers/parser.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/parsers/parser.rb
@@ -1,0 +1,14 @@
+require "json_api_client/included_data"
+require_relative "../included_data"
+module FlexCommerceApi
+  module JsonApiClientExtension
+    module Parsers
+      class Parser < ::JsonApiClient::Parsers::Parser
+        def handle_included(result_set, data)
+          result_set.included = ::FlexCommerceApi::JsonApiClientExtension::IncludedData.new(result_set, data.fetch("included", []))
+        end
+      end
+    end
+
+  end
+end

--- a/lib/flex_commerce_api/json_api_client_extension/resource.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/resource.rb
@@ -1,7 +1,9 @@
 require "json_api_client/resource"
+require_relative "./parsers/parser"
 module FlexCommerceApi
   module JsonApiClientExtension
     class Resource < JsonApiClient::Resource
+      self.parser = Parsers::Parser
       def method_missing(method, *args)
         association = association_for(method)
 

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.14'
+  VERSION = '0.6.15'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
This PR fixes an issue where if a relationship specifies a link to a resource, them gem looks for it in included data only.  However, the spec says that it can also live in the main data to avoid duplication.