### PR TITLE
Feature/4946 remote order history relationship

### DIFF
--- a/app/models/customer_account.rb
+++ b/app/models/customer_account.rb
@@ -85,34 +85,8 @@ module FlexCommerce
     end
 
     def orders
-
-      relationship_definitions = relationships[:orders]
-
-      # look in included data
-      if relationship_definitions.key?("data")
-        return last_result_set.included.data_for(:orders, relationship_definitions)
-      end
-
-      if association = association_for(:orders)
-        # look for a defined relationship url
-        if relationship_definitions["links"] && url = relationship_definitions["links"]["related"]
-          url = URI.parse(relationship_definitions["links"]["related"])
-          site = url.clone.tap {|u|
-            u.path = ""
-            u.query = nil
-            u.fragment = nil
-          }.to_s
-          path = url.clone.tap {|u|
-            u.scheme = nil
-            u.host = nil
-            u.port = nil
-            u.userinfo = nil
-          }.to_s
-
-          connection = FlexCommerceApi::JsonApiClientExtension::FlexibleConnection.new(self.class.connection_options.merge(site: site, add_json_api_extension: false, authenticate: false))
-          RemoteOrder.parser.parse(RemoteOrder, connection.run(:get, path, {}, {}))
-        end
-      end
+      return super if relationships[:orders].key?("data")
+      get_related(:orders)
     end
 
     def create_note(attributes = {})

--- a/lib/flex_commerce_api/json_api_client_extension/remote_builder.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/remote_builder.rb
@@ -1,0 +1,29 @@
+module FlexCommerceApi
+  module JsonApiClientExtension
+    class RemoteBuilder < ::JsonApiClient::Query::Builder
+      def initialize(klass, path: klass.path, connection: klass.connection)
+        super(klass)
+        self.connection = connection
+        self.path = path
+      end
+
+      def find(args = {})
+        case args
+          when Hash
+            where(args)
+          else
+            @primary_key = args
+        end
+
+        get_request(params)
+      end
+
+      private
+
+      def get_request(params)
+        klass.parser.parse(klass, connection.run(:get, path, params, klass.custom_headers))
+      end
+      attr_accessor :path, :connection
+    end
+  end
+end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.16'
+  VERSION = '0.6.17'
   API_VERSION = 'v1'
 end

--- a/spec/fixtures/customer_accounts/singular.json.erb
+++ b/spec/fixtures/customer_accounts/singular.json.erb
@@ -16,6 +16,11 @@
         "links": {
           "related": "<%= api_root %>/customer_accounts/1001/addresses"
         }
+      },
+      "orders": {
+        "links": {
+          "related": "https://in.elastic.io/hooks/somerandomhook?shopatron_customer_id=12345"
+        }
       }
 
     }

--- a/spec/integration/customer_account_spec.rb
+++ b/spec/integration/customer_account_spec.rb
@@ -297,6 +297,14 @@ RSpec.describe FlexCommerce::CustomerAccount do
           expect(subject.send(attr)).to eql value
         end
       end
+      it "should provide a paginatable object for the orders results" do
+        requests = []
+        stub_request(:get, "https://in.elastic.io/hooks/somerandomhook").with(query: hash_including(shopatron_customer_id: 12345)).to_return do |request|
+          requests << request
+          {status: 200, body: "{data: []}", headers: {"Content-Type" => "application/vnd.api+json"}}
+        end
+        results = subject.orders.page(2).per(20).to_a
+      end
     end
   end
 end

--- a/spec/integration/customer_account_spec.rb
+++ b/spec/integration/customer_account_spec.rb
@@ -299,11 +299,12 @@ RSpec.describe FlexCommerce::CustomerAccount do
       end
       it "should provide a paginatable object for the orders results" do
         requests = []
-        stub_request(:get, "https://in.elastic.io/hooks/somerandomhook").with(query: hash_including(shopatron_customer_id: 12345)).to_return do |request|
+        stub_request(:get, "https://in.elastic.io/hooks/somerandomhook").with(query: hash_including(shopatron_customer_id: "12345", page: {size: "20", number: "2"})).to_return do |request|
           requests << request
-          {status: 200, body: "{data: []}", headers: {"Content-Type" => "application/vnd.api+json"}}
+          {status: 200, body: {data: [{type: :remote_orders, id: "1", attributes: {}}]}.to_json, headers: {"Content-Type" => "application/vnd.api+json"}}
         end
-        results = subject.orders.page(2).per(20).to_a
+        expect(subject.orders.page(2).per(20).to_a).to contain_exactly(instance_of(FlexCommerce::RemoteOrder))
+        expect(requests.length).to eql 1
       end
     end
   end


### PR DESCRIPTION
The customer_account/orders relationship now uses new code to return a builder instead of doing an API call.  The API call is deferred until it is needed - but the builder can be tweaked with things like pagination, sort order etc.. as normal.