### PR TITLE
Don't fail if internal server error has no exception

### DIFF
--- a/lib/flex_commerce_api/error/internal_server.rb
+++ b/lib/flex_commerce_api/error/internal_server.rb
@@ -8,9 +8,11 @@ module FlexCommerceApi
         if error.is_a?(::Enumerable)
           title = error.fetch("title", "")
           detail = error.fetch("detail", "")
-          exception = error.fetch("meta", {"exception" => ""}).fetch("exception")
-          backtrace = error.fetch("meta", {"backtrace" => []}).fetch("backtrace")
-          "Internal server error - #{title} #{detail} #{exception} #{backtrace}"
+          meta = error.fetch("meta", {})
+          exception = meta.fetch("exception", "")
+          backtrace = meta.fetch("backtrace", [])
+          event_id = meta.fetch("event_id", "")
+          "Internal server error - #{title} #{detail} #{event_id} #{exception} #{backtrace}"
         else
           "Internal server error - #{error}"
         end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.21'
+  VERSION = '0.6.22'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
Some other changes to the platform are failing on CI https://codeship.com/projects/77160/builds/20395871?pipeline=0ca337a3-540f-4047-9a81-1ba18731a83f
because there is an API error response which has meta w/out exception, so following error is received:
```
/home/rof/cache/bundler/ruby/2.3.0/bundler/gems/flex-ruby-gem-c368639e15f3/lib/flex_commerce_api/error/internal_server.rb:11:in `fetch': key not found: "exception" (KeyError)
	from /home/rof/cache/bundler/ruby/2.3.0/bundler/gems/flex-ruby-gem-c368639e15f3/lib/flex_commerce_api/error/internal_server.rb:11:in `message'
```
this PR both fixes this and adds `event_id` (referring to sentry event) to output if it exists