### PR TITLE
removed resource type and slug from redirects

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -7,8 +7,9 @@ module FlexCommerce
   #
   class Redirect < FlexCommerceApi::ApiBase
 
-    def self.find_by_resource(source_type: nil, source_slug: nil, source_path: )
-      where({type_slug_path: { source_type: source_type, source_slug: source_slug, source_path: source_path }}).first
+    def self.find_by_path(source_path: )
+      where({source_path: { source_path: source_path }}).first
     end
+
   end
 end

--- a/spec/fixtures/redirects/multiple.json
+++ b/spec/fixtures/redirects/multiple.json
@@ -6,12 +6,9 @@
       "attributes": {
         "name": "Some Redirect",
         "status_code": 301,
-        "source_type": "products",
-        "source_slug": "old-slug",
-        "source_path": null,
-        "destination_type": "products",
-        "destination_slug": "new-slug",
-        "destination_path": null
+        "source_type": "exact",
+        "source_path": "/products/product1",
+        "destination_path": "/products/product2"
       },
       "links": {
         "self": "/facili/v1/redirects/1.json_api"
@@ -27,19 +24,19 @@
 
   "links": {
     "self": {
-      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=products&source[slug]=old-slug&source[path]=/xyz",
+      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=exact&source[path]=/xyz",
       "meta": {
         "page_number": 1
       }
     },
     "first": {
-      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=products&source[slug]=old-slug&source[path]=/xyz",
+      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=exact&source[path]=/xyz",
       "meta": {
         "page_number": 1
       }
     },
     "last": {
-      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=products&source[slug]=old-slug&source[path]=/xyz",
+      "href": "/facili/v1/redirects/matches.json_api?page=1&source[type]=exact&source[path]=/xyz",
       "meta": {
         "page_number": 1
       }

--- a/spec/integration/redirect_spec.rb
+++ b/spec/integration/redirect_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FlexCommerce::Redirect do
   describe ".find_by_resource" do
     it "should expect a path parameter" do
       expect {
-        subject_class.find_by_resource(source_slug: "bla", source_type: "bla")
+        subject_class.find_by_path()
       }.to raise_error(ArgumentError)
     end
 
@@ -21,7 +21,7 @@ RSpec.describe FlexCommerce::Redirect do
         status: 200,
         headers: default_headers
       })
-      redirect = subject_class.find_by_resource(source_slug: "old-slug", source_type: "products", source_path: "/xyz")
+      redirect = subject_class.find_by_path(source_path: "/xyz")
       expect(redirect).to be_kind_of(subject_class)
     end
   end


### PR DESCRIPTION
Related to ticket https://github.com/shiftcommerce/flex-platform/issues/5381. Remove 'resource' type and slug from redirect.
NOTE: this branch was branched from tag `v0.6.19` although there is latest `v0.6.20.2`. The problem is FE doesn't work with versions `v0.6.20` and higher. Need to update FE to support latest version and then re-branch this branch.