### PR TITLE
external url model created

### DIFF
--- a/app/models/external_url.rb
+++ b/app/models/external_url.rb
@@ -1,0 +1,6 @@
+require "flex_commerce_api/api_base"
+
+module FlexCommerce
+  class ExternalUrl < FlexCommerceApi::ApiBase
+  end
+end

--- a/lib/flex_commerce.rb
+++ b/lib/flex_commerce.rb
@@ -77,6 +77,7 @@ module FlexCommerce
   autoload :Note, File.join(gem_root, "app", "models", "note")
   autoload :PasswordRecovery, File.join(gem_root, "app", "models", "password_recovery")
   autoload :Slug, File.join(gem_root, "app", "models", "slug")
+  autoload :ExternalUrl, File.join(gem_root, "app", "models", "external_url")
 
   # Services
   autoload :ParamToShql, File.join(gem_root, "app", "services", "param_to_shql")


### PR DESCRIPTION
ExternalUrl model added so that the front end can use .canonical_path, .url or .path and access the external url related resource. 