### PR TITLE
Move logging middleware before the adapter

### DIFF
--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -25,8 +25,8 @@ module FlexCommerceApi
           end
           builder.use JsonApiClientExtension::StatusMiddleware
           builder.use JsonApiClient::Middleware::ParseJson
-          builder.adapter *adapter_options
           builder.use JsonApiClientExtension::LoggingMiddleware unless FlexCommerceApi.logger.nil?
+          builder.adapter *adapter_options
           builder.options[:open_timeout] = options.fetch(:open_timeout)
           builder.options[:timeout] = options.fetch(:timeout)
         end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.31'
+  VERSION = '0.6.32'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
Fixes thousands of deprecation warnings when running the test suite in Codeship:

![image](https://user-images.githubusercontent.com/4353861/32614725-cbd45136-c565-11e7-8efe-dc926f79c28e.png)