### PR TITLE
Add errors object to carts validate_stock! method

### DIFF
--- a/spec/integration/cart_spec.rb
+++ b/spec/integration/cart_spec.rb
@@ -242,6 +242,11 @@ RSpec.describe "Shopping Cart" do
               expect(subject.line_items[0].errors[:unit_quantity]).to include "Out of stock"
             end
 
+            it "should return an object with the line_item id and current unit_quantity" do
+              stock_errors_object = subject.validate_stock!
+              expect(stock_errors_object["742207266-0-1"]).to eq({ line_item_quantity: 3, stock_level: 0, message: "Out of stock" })
+            end
+
           end
           context "with not enough stock" do
             let(:stock_level_list) { {
@@ -267,6 +272,10 @@ RSpec.describe "Shopping Cart" do
               expect(subject.line_items[0].errors[:unit_quantity]).to include "Only 1 in stock"
             end
 
+            it "should return an object with the line_item id and current unit_quantity" do
+              stock_errors_object = subject.validate_stock!
+              expect(stock_errors_object["742207266-0-1"]).to eq({ line_item_quantity: 3, stock_level: 1, message: "Only 1 in stock" })
+            end
           end
 
         end


### PR DESCRIPTION
### Flex Platform Issue [#2237](https://github.com/shiftcommerce/matalan-rails-site/issues/2237)

As part of the fix for the issue, see Flex Platform PR [#2242](https://github.com/shiftcommerce/matalan-rails-site/pull/2242), the line items were being changed to the correct quantities when trying to checkout and the `validate_stock!` cart method was run. Currently the only output seen from the method are the errors on the line_items, so any further action had to be inferred from the error messages which isn't best practice. 

### Fix

Now when the the `validate_stock!` method is run on a cart it will return an object containing any errors about the cart when the validation ran in addition to the errors on the line items.

The object returns follows the following format:
```
{ 
  line_item_sku: {
    line_item_quantity: ...,
    stock_level: ...,
    message: ...
  },
  ...
}
```

### QA

Specs have been written to test this new functionality.

Further QA will be handled when release is added to Flex Platform PR [#2242](https://github.com/shiftcommerce/matalan-rails-site/pull/2242)