### PR TITLE
Update dependency

### DIFF
--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thor", "~> 0.19"
   spec.add_development_dependency "json_matchers", ["~> 0.5", ">= 0.5.1"]
 
-  spec.add_dependency "oj", "~> 3.3"
+  spec.add_dependency "oj", "~> 3.3.10"
   spec.add_runtime_dependency "json_api_client", "1.1.1"
   spec.add_runtime_dependency "activesupport", ">= 4.0"
   spec.add_runtime_dependency "rack", ">= 1.6"

--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thor", "~> 0.19"
   spec.add_development_dependency "json_matchers", ["~> 0.5", ">= 0.5.1"]
 
-  spec.add_dependency "oj", "3.3.6"
+  spec.add_dependency "oj", "~> 3.3"
   spec.add_runtime_dependency "json_api_client", "1.1.1"
   spec.add_runtime_dependency "activesupport", ">= 4.0"
   spec.add_runtime_dependency "rack", ">= 1.6"


### PR DESCRIPTION
Update OJ to 3.3.10

### Context
* `Oj` gem couldn't be update above version 3.3.6 because `json-schema` started failing. It turned out that `json-schema` makes use of `multi_json` gem even if it is an indirect dependency of the system and the problem was not with the `json-schema` itself but with `multi_json`, which has been patched last night due to communications that took place on the `json-schema` repository and the issue that was opened on `multi-json` repository because of that. 

