### PR TITLE
Bump version to 0.6.36

### DIFF
--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.35'
+  VERSION = '0.6.36'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
Our release versions are out of sync with the gem version specified in the gem. This simply fixes this.