### PR TITLE
Revert gem oj version to v2.12

### DIFF
--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thor", "~> 0.19"
   spec.add_development_dependency "json_matchers", ["~> 0.5", ">= 0.5.1"]
 
-  spec.add_dependency "oj", "~> 3.3.10"
+  spec.add_dependency "oj", "~> 2.12"
   spec.add_runtime_dependency "json_api_client", "1.1.1"
   spec.add_runtime_dependency "activesupport", ">= 4.0"
   spec.add_runtime_dependency "rack", ">= 1.6"

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = '0.6.36'
+  VERSION = '0.6.37'
   API_VERSION = 'v1'
 end


### PR DESCRIPTION
Gem Oj was updated in release `v0.6.35`. However, it caused issues platform side, so the gem version was kept @ v.0.6.33 . 

This PR simply updates the version in master so as to enable the latest `flex-ruby-gem`release to be used in the platform.