### PR TITLE
Issue/127 taxonomy model

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,5 +1,4 @@
 require "flex_commerce_api/api_base"
-
 module FlexCommerce
   class Taxonomy < FlexCommerceApi::ApiBase
   end

--- a/lib/flex_commerce.rb
+++ b/lib/flex_commerce.rb
@@ -68,7 +68,7 @@ module FlexCommerce
   autoload :StaticPageFolder, File.join(gem_root, "app", "models", "static_page_folder")
   autoload :StockLevel, File.join(gem_root, "app", "models", "stock_level")
   autoload :TaxCode, File.join(gem_root, "app", "models", "tax_code")
-  autoload :Taxonomy, File.join(gem_root, "app", "models", "Taxonomy")
+  autoload :Taxonomy, File.join(gem_root, "app", "models", "taxonomy")
   autoload :Template, File.join(gem_root, "app", "models", "template")
   autoload :TemplateComponent, File.join(gem_root, "app", "models", "template_component")
   autoload :TemplateDefinition, File.join(gem_root, "app", "models", "template_definition")

--- a/spec/factories/taxonomies.rb
+++ b/spec/factories/taxonomies.rb
@@ -1,7 +1,7 @@
 require "flex_commerce_api"
 
 FactoryBot.define do
-  factory :taxonomy, class: ::FlexCommerce::Taxonomy do
+  factory :taxonomy, class: FlexCommerce::Taxonomy do
     name          { Faker::Lorem.sentence }
     apply_to_all  false
     data_type     "RetailStore"

--- a/spec/factories/taxonomies.rb
+++ b/spec/factories/taxonomies.rb
@@ -1,7 +1,7 @@
 require "flex_commerce_api"
 
 FactoryBot.define do
-  factory :taxonomy, class: FlexCommerce::Taxonomy do
+  factory :taxonomy, class: ::FlexCommerce::Taxonomy do
     name          { Faker::Lorem.sentence }
     apply_to_all  false
     data_type     "RetailStore"

--- a/spec/fixtures/taxonomies/error_response.json
+++ b/spec/fixtures/taxonomies/error_response.json
@@ -1,13 +1,13 @@
 {
-	"errors": [
-		{
-			"title": "Record not found",
-			"detail": "The record identified by 123 could not be found.",
-			"code": "404",
-			"status": "404"
-		}
-	],
-	"links": {
-		"self": "/some_account/v1/taxonomies/123.json_api"
-	}
+  "errors": [
+	  {
+      "title": "Record not found",
+      "detail": "The record identified by 123 could not be found.",
+      "code": "404",
+      "status": "404"
+    }
+  ],
+  "links": {
+    "self": "/some_account/v1/taxonomies/123.json_api"
+  }
 }

--- a/spec/fixtures/taxonomies/single.json
+++ b/spec/fixtures/taxonomies/single.json
@@ -1,16 +1,16 @@
 {
-	"data": {
-		"id": "9",
-		"type": "taxonomies",
-		"links": {
-			"self": "/some_account/v1/taxonomies/9.json_api"
-		},
-		"attributes": {
-			"name": "Retail Store",
-			"data_type": "RetailStore"
-		}
-	},
-	"links": {
-		"self": "/some_account/v1/taxonomies/9.json_api"
-	}
+  "data": {
+    "id": "9",
+    "type": "taxonomies",
+    "links": {
+      "self": "/some_account/v1/taxonomies/9.json_api"
+  },
+  "attributes": {
+    "name": "Retail Store",
+    "data_type": "RetailStore"
+    }
+  },
+  "links": {
+    "self": "/some_account/v1/taxonomies/9.json_api"
+  }
 }

--- a/spec/integration/taxonomy_spec.rb
+++ b/spec/integration/taxonomy_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe FlexCommerce::Taxonomy do
         stub_request(:get, "#{api_root}/taxonomies/1.json_api").
           with(headers: { "Accept" => "application/vnd.api+json" }).
           to_return(body: build(:taxonomy_from_fixture).to_json, status: response_status, headers: default_headers)
-
         # Act
         record = described_class.find(1)
-
         # Assert
         aggregate_failures do
           expect(record).to be_present
@@ -45,11 +43,9 @@ RSpec.describe FlexCommerce::Taxonomy do
       it "should destroy the record" do
         # Arrange
         resource = build(:taxonomy, id: 1)
-
         stub_request(:delete, "#{api_root}/taxonomies/1.json_api").
           with(headers: { "Accept" => "application/vnd.api+json" }).
           to_return(status: 204, headers: default_headers)
-
         # Assert
         expect(resource.destroy).to eq(true)
       end
@@ -59,11 +55,9 @@ RSpec.describe FlexCommerce::Taxonomy do
       it "should raise an AccessDenied exception" do
         # Arrange
         resource = build(:taxonomy, id: 1)
-
         stub_request(:delete, "#{api_root}/taxonomies/1.json_api").
           with(headers: { "Accept" => "application/vnd.api+json" }).
           to_return(body: '', status: 403, headers: nil)
-
         # Act & Assert
         expect { resource.destroy }.to raise_exception(::FlexCommerceApi::Error::AccessDenied)
       end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -7,5 +7,7 @@ require "json_erb"
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
 end
-FactoryBot.find_definitions

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -7,7 +7,5 @@ require "json_erb"
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-  config.before(:suite) do
-    FactoryBot.find_definitions
-  end
 end
+FactoryBot.find_definitions


### PR DESCRIPTION
### Overview

Related GitHub issue: #127

PR adds the Taxonomy feature. 

### QA

1.) Add branch to local F/E, eg. 

```ruby
gem "flex_commerce_api", git: "https://github.com/shiftcommerce/flex-ruby-gem.git", branch: "issue/127_taxonomy_model"
``` 

*Note: Ensure your API key has permissions  to read Taxonomies.

Find an existing taxonomies id either using rails c or through your admin panel.

### Fetch the Taxonomy
```
$ FlexCommerce::Taxonomy.find(id)
=> `taxonomy`
```