### PR TITLE
Hotfix/Make surrogate keys unique

### DIFF
--- a/app/services/surrogate_keys.rb
+++ b/app/services/surrogate_keys.rb
@@ -37,6 +37,7 @@ module FlexCommerce
       # Check if surrogate key is available, if not initiate it
       Thread.current[:shift_surrogate_keys] ||= []
       Thread.current[:shift_surrogate_keys] += keys.flatten
+      Thread.current[:shift_surrogate_keys] = Thread.current[:shift_surrogate_keys].uniq
     end
 
   end


### PR DESCRIPTION
Surrogate keys class is not checking for uniqueness of keys. Having duplicate keys will increase the length of the key, which in turn may result in it exceeding its character limit.

This PR handles it by updating it to be uniq.