### PR TITLE
Issue/137 update template section association

### DIFF
--- a/app/models/template_section.rb
+++ b/app/models/template_section.rb
@@ -5,7 +5,6 @@ module FlexCommerce
   #
   # This model provides access to the flex commerce template section
   #
-  #
   class TemplateSection < FlexCommerceApi::ApiBase
     belongs_to :template_definition, class_name: "::FlexCommerce::TemplateDefinition"
     has_many :template_components, class_name: "::FlexCommerce::TemplateComponent"

--- a/spec/factories/template_sections.rb
+++ b/spec/factories/template_sections.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  klass = Struct.new(:label, :reference, :preview_icon)
+
+  factory :template_section, class: klass do
+    label       { Faker::Lorem.sentence }
+    reference   { Faker::Lorem.characters(5) }
+  end
+
+  factory :template_section_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/template_sections/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+
+  factory :template_sections_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/template_sections/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+end

--- a/spec/fixtures/template_sections/multiple.json
+++ b/spec/fixtures/template_sections/multiple.json
@@ -1,0 +1,175 @@
+{
+  "meta": {
+    "type": "template_sections",
+    "page_count": 2,
+    "total_entries": 11
+  },
+  "links": {
+    "self": "/test/v1/template_sections/1.json_api",
+    "next": "/test/v1/template_sections/2.json_api",
+    "first": "/test/v1/template_sections/1.json_api",
+    "last": "/test/v1/template_sections/2.json_api"
+  },
+  "data": [
+    {
+      "type": "template_sections",
+      "id": "1",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/1.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "2",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/2.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "3",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/3.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "4",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/4.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "5",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/5.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "6",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/6.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "7",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/7.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "8",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/8.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "9",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/9.json_api"
+      }
+    },
+    {
+      "type": "template_sections",
+      "id": "10",
+      "attributes": {
+        "label": "label",
+        "reference": "reference",
+        "min_components": "1",
+        "max_components": "2",
+        "position": "1",
+        "preview_icon": "null",
+        "template_definition_id": "1"
+      },
+      "links": {
+        "self": "/test/v1/template_sections/10.json_api"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/template_sections/singular.json
+++ b/spec/fixtures/template_sections/singular.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "id": "1",
+    "type": "template_sections",
+    "attributes": {
+      "label": "label",
+      "reference": "reference",
+      "min_components": "1",
+      "max_components": "2",
+      "position": "1",
+      "preview_icon": "null",
+      "template_definition_id": "1"
+    },
+    "links": {
+      "self": "test/v1/template_sections/1"
+    },
+    "relationships": {
+      "template_definition": {
+        "links": {
+          "related": "test/v1/template_definitions/1"
+        },
+        "data": {
+          "type": "template_definitions",
+          "id":   "1"
+        }
+      },
+      "template_components": {
+        "links": {
+          "related": "test/v1/template_components/1"
+        },
+        "data": {
+          "items": {
+            "type": "template_components",
+            "id":   "1"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/integration/template_section.rb
+++ b/spec/integration/template_section.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::TemplateSection do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { ::FlexCommerce::TemplateSection }
+
+  context "with fixture files from flex" do
+    context "working with a single category" do
+      let(:singular_resource) { build(:template_section_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/template_definitions/1/template_sections/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.where(template_definition_id: 1).find(1).first }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+    end
+
+    context "working with multiple template_sections" do
+      let(:resource_list) { build(:template_sections_from_fixture) }
+      let(:quantity) { 11 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 10 }
+      subject { subject_class.where(template_definition_id: 1).all }
+      before :each do
+        stub_request(:get, "#{api_root}/template_definitions/1/template_sections.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+    end
+  end
+end

--- a/spec/integration/template_section.rb
+++ b/spec/integration/template_section.rb
@@ -10,7 +10,7 @@ RSpec.describe FlexCommerce::TemplateSection do
   let(:subject_class) { ::FlexCommerce::TemplateSection }
 
   context "with fixture files from flex" do
-    context "working with a single category" do
+    context "working with a single template section" do
       let(:singular_resource) { build(:template_section_from_fixture) }
       before :each do
         stub_request(:get, "#{api_root}/template_definitions/1/template_sections/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers


### PR DESCRIPTION
### The issue #137 

In order for template sections to be nested behind template definitions, the association needed to be updated so that the gem can form the correct url.

### The fix

change `has_one` to `belongs_to`