### PR TITLE
belongs to added to model, fixtures and specs added

### DIFF
--- a/app/models/bundle_group.rb
+++ b/app/models/bundle_group.rb
@@ -9,6 +9,7 @@ module FlexCommerce
   #
   #
   class BundleGroup < FlexCommerceApi::ApiBase
+    belongs_to :bundle, class_name: "::FlexCommerce::Bundle"
     has_many :products, class_name: "::FlexCommerce::Product"
   end
 end

--- a/spec/factories/bundle_groups.rb
+++ b/spec/factories/bundle_groups.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  klass = Struct.new(:name, :sequence)
+  factory :bundle_group, class: klass do
+    name { Faker::Name.title }
+    sequence(:sort) { |n| n }
+    association :bundle
+  end
+  factory :bundle_groups_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/bundle_groups/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+  factory :bundle_group_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/bundle_groups/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+end

--- a/spec/fixtures/bundle_groups/multiple.json
+++ b/spec/fixtures/bundle_groups/multiple.json
@@ -1,0 +1,145 @@
+{
+  "meta": {
+    "type": "bundle_groups",
+    "page_count": 2,
+    "total_entries": 11
+  },
+  "links": {
+    "self": "/test/v1/bundle/1/bundle_groups/1.json_api",
+    "next": "/test/v1/bundle/1/bundle_groups/2.json_api",
+    "first": "/test/v1/bundle/1/bundle_groups/1.json_api",
+    "last": "/test/v1/bundle/1/bundle_groups/2.json_api"
+  },
+  "data": [
+    {
+      "type": "bundle_groups",
+      "id": "1",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/1.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "2",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/2.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "3",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/2.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "4",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/4.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "5",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/5.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "6",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/6.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "7",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/7.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "8",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/8.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "9",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/9.json_api"
+      }
+    },
+    {
+      "type": "bundle_groups",
+      "id": "10",
+      "attributes": {
+        "name": "name",
+        "sort": 1,
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/bundle_groups/10.json_api"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/bundle_groups/singular.json
+++ b/spec/fixtures/bundle_groups/singular.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "id": "1",
+    "type": "bundle_groups",
+    "attributes": {
+      "name": "name",
+      "sort": 1,
+      "updated_at": "2017-09-12T07:40:58Z",
+      "created_at": "2017-03-21T09:19:57Z"
+    },
+    "links": {
+      "self": "/test/v1/bundles/1/bundle_groups/1"
+    },
+    "relationships": {
+      "products": {
+        "links": {
+          "self":  "/test/v1/bundles/1/bundle_groups/1",
+          "related":  "/test/v1/bundle_groups/1/products"
+        }
+      }
+    }
+  }
+}

--- a/spec/integration/bundle_group.rb
+++ b/spec/integration/bundle_group.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::BundleGroup do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { ::FlexCommerce::BundleGroup }
+  let(:product_class) { ::FlexCommerce::Product }
+
+  context "with fixture files from flex" do
+    context "working with a single bundle group" do
+      let(:singular_resource) { build(:bundle_group_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/bundles/1/bundle_groups/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.where(bundle_id: 1).find(1).first }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+    end
+    context "working with multiple bundle groups" do
+      let(:resource_list) { build(:bundle_groups_from_fixture) }
+      let(:quantity) { 11 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 10 }
+      subject { subject_class.where(bundle_id: 1).all }
+      before :each do
+        stub_request(:get, "#{api_root}/bundles/1/bundle_groups.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+    end
+  end
+end


### PR DESCRIPTION
### The issue

Bundle groups aren't multi-tenanted so need to be nested behind bundles.

### The fix 

Add belongs_to association to bundle group model.

### QA

Using this branch set up a bundle group with an associated bundle and interact with it via `FlexCommerce::BundleGroup.where(bundle_id: 123).find(123)`
`FlexCommerce::BundleGroup.where(bundle_id: 123).all`
`FlexCommerce::BundleGroup.where(bundle_id: 123).create{bindle_group_attributes}`