### PR TITLE
menu item model updated,specs added

### DIFF
--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,16 +1,5 @@
 require "flex_commerce_api/api_base"
 module FlexCommerce
-  #
-  # A flex commerce menu item model
-  #
-  # This model is used by the Menu model as an association so is not
-  # usable directly on the API as there is no corresponding URL.
-  #
-  # Each menu item has many menu items (i.e. nested) which are generally
-  # all loaded up front, so this should be a relatively inexpensive operation
-  # in order to build a menu system on the front end application.
-  #
-  #
   class MenuItem < FlexCommerceApi::ApiBase
     belongs_to :menu, class_name: "::FlexCommerce::Menu"
     has_many :menu_items

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -11,7 +11,8 @@ module FlexCommerce
   # in order to build a menu system on the front end application.
   #
   #
-class MenuItem < FlexCommerceApi::ApiBase
+  class MenuItem < FlexCommerceApi::ApiBase
+    belongs_to :menu, class_name: "::FlexCommerce::Menu"
     has_many :menu_items
   end
 end

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  klass = Struct.new(:title)
+  factory :menu_item, class: klass do
+    title       { Faker::Lorem.sentence }
+    association :menu
+  end
+  factory :menu_items_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/menu_items/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+  factory :menu_item_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/menu_items/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+end

--- a/spec/fixtures/menu_items/multiple.json
+++ b/spec/fixtures/menu_items/multiple.json
@@ -5,18 +5,18 @@
     "total_entries": 11
   },
   "links": {
-    "self": "/test/v1/bundle/1/menu_items/1.json_api",
-    "next": "/test/v1/bundle/1/menu_items/2.json_api",
-    "first": "/test/v1/bundle/1/menu_items/1.json_api",
-    "last": "/test/v1/bundle/1/menu_items/2.json_api"
+    "self": "/test/v1/menu/1/menu_items/1.json_api",
+    "next": "/test/v1/menu/1/menu_items/2.json_api",
+    "first": "/test/v1/menu/1/menu_items/1.json_api",
+    "last": "/test/v1/menu/1/menu_items/2.json_api"
   },
   "data": [
     {
       "type": "menu_items",
       "id": "1",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -24,15 +24,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/1.json_api"
+        "self": "/test/v1/menu/1/menu_items/1.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "2",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -40,15 +40,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/2.json_api"
+        "self": "/test/v1/menu/1/menu_items/2.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "3",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -56,15 +56,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/3.json_api"
+        "self": "/test/v1/menu/1/menu_items/3.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "4",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -72,15 +72,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/4.json_api"
+        "self": "/test/v1/menu/1/menu_items/4.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "5",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -88,15 +88,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/5.json_api"
+        "self": "/test/v1/menu/1/menu_items/5.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "6",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -104,15 +104,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/6.json_api"
+        "self": "/test/v1/menu/1/menu_items/6.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "7",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -120,15 +120,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/7.json_api"
+        "self": "/test/v1/menu/1/menu_items/7.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "8",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -136,15 +136,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/8.json_api"
+        "self": "/test/v1/menu/1/menu_items/8.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "9",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -152,15 +152,15 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/9.json_api"
+        "self": "/test/v1/menu/1/menu_items/9.json_api"
       }
     },
     {
       "type": "menu_items",
       "id": "10",
       "attributes": {
-        "title": { "type": "string" },
-        "published":{ "type": "boolean" },
+        "title": "title",
+        "published": false,
         "canonical_path": "menus/1/menu_items/1",
         "meta_attributes": {},
         "updated_at": "2017-09-12T07:40:58Z",
@@ -168,7 +168,7 @@
         "deleted_at": "null"
       },
       "links": {
-        "self": "/test/v1/bundle/1/menu_items/10.json_api"
+        "self": "/test/v1/menu/1/menu_items/10.json_api"
       }
     }
   ]

--- a/spec/fixtures/menu_items/multiple.json
+++ b/spec/fixtures/menu_items/multiple.json
@@ -1,0 +1,175 @@
+{
+  "meta": {
+    "type": "menu_items",
+    "page_count": 2,
+    "total_entries": 11
+  },
+  "links": {
+    "self": "/test/v1/bundle/1/menu_items/1.json_api",
+    "next": "/test/v1/bundle/1/menu_items/2.json_api",
+    "first": "/test/v1/bundle/1/menu_items/1.json_api",
+    "last": "/test/v1/bundle/1/menu_items/2.json_api"
+  },
+  "data": [
+    {
+      "type": "menu_items",
+      "id": "1",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/1.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "2",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/2.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "3",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/3.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "4",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/4.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "5",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/5.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "6",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/6.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "7",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/7.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "8",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/8.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "9",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/9.json_api"
+      }
+    },
+    {
+      "type": "menu_items",
+      "id": "10",
+      "attributes": {
+        "title": { "type": "string" },
+        "published":{ "type": "boolean" },
+        "canonical_path": "menus/1/menu_items/1",
+        "meta_attributes": {},
+        "updated_at": "2017-09-12T07:40:58Z",
+        "created_at": "2017-03-21T09:19:57Z",
+        "deleted_at": "null"
+      },
+      "links": {
+        "self": "/test/v1/bundle/1/menu_items/10.json_api"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/menu_items/singular.json
+++ b/spec/fixtures/menu_items/singular.json
@@ -1,0 +1,63 @@
+{
+  "data": {
+    "id": "1",
+    "type": "menu_items",
+    "attributes": {
+      "title": "title",
+      "published": "false",
+      "canonical_path": "menus/id/menu_item/id",
+      "meta_attributes": {},
+      "updated_at": "2017-09-12T07:40:58Z",
+      "created_at": "2017-03-21T09:19:57Z",
+      "deleted_at": "null"
+    },
+    "relationships": {
+      "item": {
+        "links": {
+          "self": "/test/v1/menu_items/4.json_api",
+          "related": "/test/v1/retail_stores/4.json_api"
+        },
+        "data": {
+          "type": "retail_store",
+          "id":   1
+        }
+      },
+      "menu_items": {
+        "links": {
+          "self": "/test/v1/menu_items/4.json_api",
+          "related": "/test/v1/menu_items/5.json_api"
+        },
+        "data": {
+          "items": {
+            "type": "retail_store",
+            "id":   1
+          }
+        }
+      }
+    },
+    "links": {
+      "self": "/test/v1/menu_items/1"
+    }
+  },
+  "included": [
+    {
+      "id": "1",
+      "type": "categories",
+      "attributes": {
+        "title": "Furniture"
+      },
+      "links": {
+        "self": "/test/v1/categories/furniture.json_api"
+      }
+    },
+    {
+      "id": "1",
+      "type": "template_definitions",
+      "attributes": {
+        "label": "Category",
+        "reference": "category",
+        "data_type": "Category"
+      }
+    }
+  ]
+}

--- a/spec/integration/menu_item_spec.rb
+++ b/spec/integration/menu_item_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::MenuItem do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { ::FlexCommerce::MenuItem }
+
+  context "with fixture files from flex" do
+    context "working with a single menu item" do
+      let(:singular_resource) { build(:menu_item_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/menus/1/menu_items/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.where(menu_id: 1).find(1).first }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+    end
+    context "working with multiple menu_items" do
+      let(:resource_list) { build(:menu_items_from_fixture) }
+      let(:quantity) { 11 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 10 }
+      subject { subject_class.where(menu_id: 1).all }
+      before :each do
+        stub_request(:get, "#{api_root}/menus/1/menu_items.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+    end
+  end
+end


### PR DESCRIPTION
### Issue #143 

### The issue

Menu items are not multi-tenanted.

### The fix

Menu items need to be nested behind a multi-tenanted model, in this case menu. Adding belongs_to :menu will allow the gem to access the new routes which are menus/id/menu_items for example.

This will need to be done before shiftcommerce/flex-platform#6957 is implemented.

### QA 

Using this branch, create a menu item that is associated with a menu using the gem e.g
`FlexCommerce::MenuItem.create(valid_attributes.merge(menu_id: menu.id))`

Fetch the menu item:

`FlexCommerce::MenuItem.where(menu_id: menu.id).find(id)`

Fetch all the menu items:

`FlexCommerce::MenuItem.where(menu_id: menu.id).all`

perform update and delete actions on the menu item.

`resource = FlexCommerce::MenuItem.where(menu_id: menu.id).find(id)`
`resource.update_attributes(title: "new_title")`
`resource.destroy`

Expect all the actions to work correctly.