### PR TITLE
markdown association updated, specs added

### DIFF
--- a/app/models/markdown_price.rb
+++ b/app/models/markdown_price.rb
@@ -2,7 +2,7 @@ require "flex_commerce_api/api_base"
 
 module FlexCommerce
   class MarkdownPrice < FlexCommerceApi::ApiBase
-    has_one :variant
+    belongs_to :variant
 
     def active?
       Time.now.between?(start_at, end_at)

--- a/spec/factories/markdown_prices.rb
+++ b/spec/factories/markdown_prices.rb
@@ -7,4 +7,17 @@ FactoryBot.define do
     end_at    { Faker::Date.between(2.days.ago, Date.today) }
   end
 
+  factory :markdown_prices_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/markdown_prices/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+  factory :markdown_price_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/markdown_prices/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+
 end

--- a/spec/fixtures/markdown_prices/multiple.json
+++ b/spec/fixtures/markdown_prices/multiple.json
@@ -1,0 +1,135 @@
+{
+  "meta": {
+    "type": "markdown_prices",
+    "page_count": 2,
+    "total_entries": 11
+  },
+  "links": {
+    "self": "/similiq/v1/markdown_prices/pages/1.json_api",
+    "next": "/similiq/v1/markdown_prices/pages/2.json_api",
+    "first": "/similiq/v1/markdown_prices/pages/1.json_api",
+    "last": "/similiq/v1/markdown_prices/pages/2.json_api"
+  },
+  "data": [
+    {
+      "type": "markdown_prices",
+      "id": "1",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/847565910.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "2",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/766693800.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "3",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/202036844.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "4",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/780902696.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "5",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/703918953.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "6",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/409877925.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "7",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/556481336.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "8",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/650431290.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "9",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/46496589.json_api"
+      }
+    },
+    {
+      "type": "markdown_prices",
+      "id": "10",
+      "attributes": {
+        "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+      },
+      "links": {
+        "self": "/similiq/v1/markdown_prices/388659846.json_api"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/markdown_prices/singular.json
+++ b/spec/fixtures/markdown_prices/singular.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "id": "1",
+    "type": "markdown_prices",
+    "attributes": {
+      "start_at": "2017-09-12T07:40:58Z",
+        "end_at": "2017-03-21T09:19:57Z",
+        "price": 10
+    },
+    "relationships": {
+      "products": {
+        "links": {
+          "related": "/test/v1/variants/1.json_api"
+        }
+      }
+    },
+    "links": {
+      "self": "/test/v1/markdown_prices/1"
+    }
+  },
+  "included": [
+    {
+      "id": "1",
+      "type": "variant",
+      "attributes": {
+        "title": "title"
+      },
+      "links": {
+        "self": "/test/v1/variants/1.json_api"
+      }
+    }
+  ]
+}

--- a/spec/integration/markdown_price_spec.rb
+++ b/spec/integration/markdown_price_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::MarkdownPrice do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { FlexCommerce::MarkdownPrice }
+
+  context "with fixture files from flex" do
+    context "working with a single markdown_price" do
+      let(:singular_resource) { build(:markdown_price_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/variants/1/markdown_prices/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.where(variant_id: 1).find(1).first }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+    end
+    context "working with multiple markdown_prices" do
+      let(:resource_list) { build(:markdown_prices_from_fixture) }
+      let(:quantity) { 11 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 10 }
+      subject { subject_class.where(variant_id: 1).all }
+      before :each do
+        stub_request(:get, "#{api_root}/variants/1/markdown_prices.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+    end
+  end
+end

--- a/spec/integration/meta_attributes_spec.rb
+++ b/spec/integration/meta_attributes_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "url encoding on any model" do
     MetaAttributableClass = Class.new(FlexCommerceApi::ApiBase) do
     end
   end
-   
-  before(:each) do 
+
+  before(:each) do
     stub_request(:get, /\/meta_attributable_classes\/slug:my_slug\.json_api$/).to_return do |req|
       { body: example_data.to_json, headers: default_headers, status: 200 }
     end
@@ -21,17 +21,17 @@ RSpec.describe "url encoding on any model" do
 
   context 'with meta data' do
     let!(:example_data) do
-      { 
+      {
         data: {
-          id: "1", 
-          type: "meta_attributable_class", 
+          id: "1",
+          type: "meta_attributable_class",
           attributes: {
-            meta_attributes: { foo: { value: "bar", data_type: "text" } } 
-          } 
-        } 
+            meta_attributes: { foo: { value: "bar", data_type: "text" } }
+          }
+        }
       }
     end
-   
+
     let(:result) { subject_class.find("slug:my_slug") }
 
     it 'allows get by meta attribute method' do


### PR DESCRIPTION
### The issue #145 

Markdown prices are not multi-tenanted.

### The fix

Nested markdown prices behind the multi-tenanted variants. This PR is needed for that to happen so the url can become `variants/id/markdown_prices/id`, or `MarkdownPrice.where(variant_id: variant.id).find(123)` through the gem.

### QA

Using this branch create, update, read a markdown price through the gem. You will need a variant id in order to do this.

using the gem, expect the following actions to work as expected:

Create = `FlexCommerce::MarkdownPrice.create(valid_attributes.merge(variant_id: variant.id))`
Read = `FlexCommerce::MarkdownPrice.where(variant_id: variant.id).find(markdown_price.id)`
Read = `FlexCommerce::MarkdownPrice.where(variant_id: variant.id).all`
Update = `resource = FlexCommerce::MarkdownPrice.where(variant_id: variant.id).find(markdown_price.id).first`
`resource.update_attributes(price: 20)`
Delete = `resource = FlexCommerce::MarkdownPrice.where(variant_id: variant.id).find(markdown_price.id).first`
`resource.destroy`