### PR TITLE
specs added for the newly created import and import entry models

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,0 +1,10 @@
+require "flex_commerce_api/api_base"
+module FlexCommerce
+  #
+  # A flex commerce Category tree model
+  #
+  # This model provides access to the flex commerce category tree and associated categories.
+  class Import < FlexCommerceApi::ApiBase
+    has_many :import_entries, class_name: "FlexCommerce::ImportEntry"
+  end
+end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,9 +1,5 @@
 require "flex_commerce_api/api_base"
 module FlexCommerce
-  #
-  # A flex commerce Category tree model
-  #
-  # This model provides access to the flex commerce category tree and associated categories.
   class Import < FlexCommerceApi::ApiBase
     has_many :import_entries, class_name: "FlexCommerce::ImportEntry"
   end

--- a/app/models/import_entry.rb
+++ b/app/models/import_entry.rb
@@ -1,0 +1,10 @@
+require "flex_commerce_api/api_base"
+module FlexCommerce
+  #
+  # A flex commerce Category tree model
+  #
+  # This model provides access to the flex commerce category tree and associated categories.
+  class ImportEntry < FlexCommerceApi::ApiBase
+    belongs_to :import, class_name: "FlexCommerce::Import"
+  end
+end

--- a/app/models/import_entry.rb
+++ b/app/models/import_entry.rb
@@ -1,9 +1,5 @@
 require "flex_commerce_api/api_base"
 module FlexCommerce
-  #
-  # A flex commerce Category tree model
-  #
-  # This model provides access to the flex commerce category tree and associated categories.
   class ImportEntry < FlexCommerceApi::ApiBase
     belongs_to :import, class_name: "FlexCommerce::Import"
   end

--- a/lib/flex_commerce.rb
+++ b/lib/flex_commerce.rb
@@ -28,6 +28,8 @@ module FlexCommerce
   autoload :EwisOptIn, File.join(gem_root, "app", "models", "ewis_opt_in")
   autoload :ExternalUrl, File.join(gem_root, "app", "models", "external_url")
   autoload :FreeShippingPromotion, File.join(gem_root, "app", "models", "free_shipping_promotion")
+  autoload :Import, File.join(gem_root, "app", "models", "import")
+  autoload :ImportEntry, File.join(gem_root, "app", "models", "import_entry")
   autoload :LineItem, File.join(gem_root, "app", "models", "line_item")
   autoload :LineItemDiscount, File.join(gem_root, "app", "models", "line_item_discount")
   autoload :MarkdownPrice, File.join(gem_root, "app", "models", "markdown_price")

--- a/spec/factories/import_entries.rb
+++ b/spec/factories/import_entries.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :import_entries_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/import_entries/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+  factory :import_entry_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/import_entries/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+end

--- a/spec/factories/imports.rb
+++ b/spec/factories/imports.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :imports_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/imports/multiple.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+  factory :import_from_fixture, class: JsonStruct do
+    obj = JsonStruct.new(JSON.parse(File.read("spec/fixtures/imports/singular.json")))
+    obj.each_pair do |key, value|
+      send(key, value)
+    end
+  end
+end

--- a/spec/fixtures/import_entries/multiple.json
+++ b/spec/fixtures/import_entries/multiple.json
@@ -1,0 +1,135 @@
+{
+  "meta": {
+    "type": "import_entries",
+    "page_count": 2,
+    "total_entries": 11
+  },
+  "links": {
+    "self": "/test/v1/import_entries/pages/1.json_api",
+    "next": "/test/v1/import_entries/pages/2.json_api",
+    "first": "/test/v1/import_entries/pages/1.json_api",
+    "last": "/test/v1/import_entries/pages/2.json_api"
+  },
+  "data": [
+    {
+      "type": "import_entries",
+      "id": "6",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/847565910.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "11",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/766693800.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "7",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/202036844.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "13",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/780902696.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "12",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/703918953.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "14",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/409877925.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "9",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/556481336.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "5",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/650431290.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "15",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/46496589.json_api"
+      }
+    },
+    {
+      "type": "import_entries",
+      "id": "8",
+      "attributes": {
+        "status": "processed",
+        "body": "object",
+        "processing_errors": []
+      },
+      "links": {
+        "self": "/test/v1/import_entries/388659846.json_api"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/import_entries/singular.json
+++ b/spec/fixtures/import_entries/singular.json
@@ -8,14 +8,14 @@
       "processing_errors": []
     },
     "relationships": {
-      "categories": {
+      "import": {
         "links": {
-          "related": "/test/v1/imports/1/import_entries"
+          "related": "/test/v1/imports/1"
         }
       }
     },
     "links": {
-      "self": "/test/v1/imports/1"
+      "self": "/test/v1/imports/1/import_entries/1"
     }
   },
   "included": []

--- a/spec/fixtures/import_entries/singular.json
+++ b/spec/fixtures/import_entries/singular.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": "1",
+    "type": "imports",
+    "attributes": {
+      "status": "processed",
+      "body": {},
+      "processing_errors": []
+    },
+    "relationships": {
+      "categories": {
+        "links": {
+          "related": "/test/v1/imports/1/import_entries"
+        }
+      }
+    },
+    "links": {
+      "self": "/test/v1/imports/1"
+    }
+  },
+  "included": []
+}

--- a/spec/fixtures/imports/multiple.json
+++ b/spec/fixtures/imports/multiple.json
@@ -24,9 +24,9 @@
         "updated_at": "2017-03-21T09:19:57Z"
       },
       "relationships": {
-        "categories": {
+        "import_entries": {
           "links": {
-            "related": "/test/v1/imports/2/categories"
+            "related": "/test/v1/imports/2/import_entries/1"
           }
         }
       },
@@ -48,7 +48,7 @@
         "updated_at": "2017-03-21T09:19:57Z"
       },
       "relationships": {
-        "categories": {
+        "import_entries": {
           "links": {
             "related": "/test/v1/imports/1/import_entries"
           }

--- a/spec/fixtures/imports/multiple.json
+++ b/spec/fixtures/imports/multiple.json
@@ -1,0 +1,62 @@
+{
+  "meta": {
+    "type": "imports",
+    "page_count": 1,
+    "total_entries": 2
+  },
+  "links": {
+    "self": "/test/v1/imports.json_api?page=1",
+    "first": "/test/v1/imports.json_api?page=1",
+    "last": "/test/v1/imports.json_api?page=1"
+  },
+  "data": [
+    {
+      "id": "2",
+      "type": "imports",
+      "attributes": {
+        "status": "processed",
+        "importer_type": "products",
+        "processing_errors": [],
+        "processed_entries": 1,
+        "failed_entries": 0,
+        "total_entries": 1,
+        "created_at": "2017-09-12T07:40:58Z",
+        "updated_at": "2017-03-21T09:19:57Z"
+      },
+      "relationships": {
+        "categories": {
+          "links": {
+            "related": "/test/v1/imports/2/categories"
+          }
+        }
+      },
+      "links": {
+        "self": "/test/v1/imports/2"
+      }
+    },
+    {
+      "id": "1",
+      "type": "imports",
+      "attributes": {
+        "status": "processed",
+        "importer_type": "products",
+        "processing_errors": [],
+        "processed_entries": 1,
+        "failed_entries": 0,
+        "total_entries": 1,
+        "created_at": "2017-09-12T07:40:58Z",
+        "updated_at": "2017-03-21T09:19:57Z"
+      },
+      "relationships": {
+        "categories": {
+          "links": {
+            "related": "/test/v1/imports/1/import_entries"
+          }
+        }
+      },
+      "links": {
+        "self": "/test/v1/imports/1"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/imports/singular.json
+++ b/spec/fixtures/imports/singular.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "id": "1",
+    "type": "imports",
+    "attributes": {
+      "status": "processed",
+      "importer_type": "products",
+      "processing_errors": [],
+      "processed_entries": 1,
+      "failed_entries": 0,
+      "total_entries": 1,
+      "created_at": "2017-09-12T07:40:58Z",
+      "updated_at": "2017-03-21T09:19:57Z"
+    },
+    "relationships": {
+      "import_entries": {
+        "links": {
+          "related": "/test/v1/imports/1/import_entries"
+        }
+      }
+    },
+    "links": {
+      "self": "/test/v1/imports/1"
+    }
+  },
+  "included": []
+}

--- a/spec/integration/import_entry_spec.rb
+++ b/spec/integration/import_entry_spec.rb
@@ -12,17 +12,22 @@ RSpec.describe FlexCommerce::ImportEntry do
   context "with fixture files from flex" do
     context "working with a single import entry" do
       let(:singular_resource) { build(:import_entry_from_fixture) }
+
       before :each do
         stub_request(:get, "#{api_root}/imports/1/import_entries/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
       end
+
       subject { subject_class.where(import_id: 1).find(1).first }
+
       it_should_behave_like "a singular resource with an error response"
+
       it "should return the correct top level object" do
         expect(subject).to be_a(subject_class)
         expect(subject.title).to eql singular_resource.data.attributes.title
         expect(subject.reference).to eql singular_resource.data.attributes.reference
       end
     end
+
     context "working with multiple import_entries" do
       let(:resource_list) { build(:import_entries_from_fixture) }
       let(:quantity) { 11 }
@@ -30,12 +35,13 @@ RSpec.describe FlexCommerce::ImportEntry do
       let(:current_page) { nil }
       let(:expected_list_quantity) { 10 }
       subject { subject_class.where(import_id: 1).all }
+
       before :each do
         stub_request(:get, "#{api_root}/imports/1/import_entries.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
       end
+
       it_should_behave_like "a collection of anything"
       it_should_behave_like "a collection of resources with an error response"
-
     end
   end
 end

--- a/spec/integration/import_entry_spec.rb
+++ b/spec/integration/import_entry_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FlexCommerce::ImportEntry do
   let(:subject_class) { ::FlexCommerce::ImportEntry }
 
   context "with fixture files from flex" do
-    context "working with a single category" do
+    context "working with a single import entry" do
       let(:singular_resource) { build(:import_entry_from_fixture) }
       before :each do
         stub_request(:get, "#{api_root}/imports/1/import_entries/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers

--- a/spec/integration/import_entry_spec.rb
+++ b/spec/integration/import_entry_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::ImportEntry do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { ::FlexCommerce::ImportEntry }
+
+  context "with fixture files from flex" do
+    context "working with a single category" do
+      let(:singular_resource) { build(:import_entry_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/imports/1/import_entries/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.where(import_id: 1).find(1).first }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+    end
+    context "working with multiple import_entries" do
+      let(:resource_list) { build(:import_entries_from_fixture) }
+      let(:quantity) { 11 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 10 }
+      subject { subject_class.where(import_id: 1).all }
+      before :each do
+        stub_request(:get, "#{api_root}/imports/1/import_entries.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+
+    end
+  end
+end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::Import do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+  let(:subject_class) { ::FlexCommerce::Import }
+  let(:import_entry_class) { ::FlexCommerce::ImportEntry }
+
+  context "with fixture files from flex" do
+    context "working with a single import_entry tree" do
+      let(:singular_resource) { build(:import_from_fixture) }
+      before :each do
+        stub_request(:get, "#{api_root}/imports/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+      end
+      subject { subject_class.find(1) }
+      it_should_behave_like "a singular resource with an error response"
+      it "should return the correct top level object" do
+        expect(subject).to be_a(subject_class)
+        expect(subject.title).to eql singular_resource.data.attributes.title
+        expect(subject.reference).to eql singular_resource.data.attributes.reference
+      end
+      context "using the import entries association" do
+        before :each do
+          stub_request(:get, "#{flex_root}#{singular_resource.data.relationships.import_entries.links.related}").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: multiple_import_entry_resources.to_h.to_json, status: response_status, headers: default_headers
+          stub_request(:get, "#{flex_root}#{singular_resource.data.relationships.import_entries.links.related}.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: multiple_import_entry_resources.to_h.to_json, status: response_status, headers: default_headers
+        end
+        let(:multiple_import_entry_resources) { build(:import_entries_from_fixture) }
+        it "should return a list of import_entries" do
+          subject.import_entries.tap do |import_entries|
+            expect(import_entries.length).to eql multiple_import_entry_resources.data.length
+            import_entries.each_with_index do |import_entry, idx|
+              expect(import_entry).to be_a(import_entry_class)
+            end
+          end
+        end
+        it "should return a list of import_entries with the correct attributes" do
+          subject.import_entries.tap do |import_entries|
+            expect(import_entries.length).to eql multiple_import_entry_resources.data.length
+            import_entries.each_with_index do |import_entry, idx|
+              resource = multiple_import_entry_resources.data[idx]
+              resource.attributes.each_pair do |attr, value|
+                expect(import_entry.send(attr)).to eql value
+              end
+            end
+          end
+        end
+      end
+    end
+    context "working with multiple import_entry trees" do
+      let(:resource_list) { build(:imports_from_fixture) }
+      let(:quantity) { 2 }
+      let(:total_pages) { resource_list.meta.page_count }
+      let(:current_page) { nil }
+      let(:expected_list_quantity) { 2 }
+      subject { subject_class.all }
+      before :each do
+        stub_request(:get, "#{api_root}/imports.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
+      end
+      it_should_behave_like "a collection of anything"
+      it_should_behave_like "a collection of resources with an error response"
+    end
+  end
+end

--- a/spec/integration/import_spec.rb
+++ b/spec/integration/import_spec.rb
@@ -13,22 +13,29 @@ RSpec.describe FlexCommerce::Import do
   context "with fixture files from flex" do
     context "working with a single import_entry tree" do
       let(:singular_resource) { build(:import_from_fixture) }
+      
       before :each do
         stub_request(:get, "#{api_root}/imports/1.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
       end
+
       subject { subject_class.find(1) }
       it_should_behave_like "a singular resource with an error response"
+
       it "should return the correct top level object" do
         expect(subject).to be_a(subject_class)
         expect(subject.title).to eql singular_resource.data.attributes.title
         expect(subject.reference).to eql singular_resource.data.attributes.reference
       end
+
       context "using the import entries association" do
+
         before :each do
           stub_request(:get, "#{flex_root}#{singular_resource.data.relationships.import_entries.links.related}").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: multiple_import_entry_resources.to_h.to_json, status: response_status, headers: default_headers
           stub_request(:get, "#{flex_root}#{singular_resource.data.relationships.import_entries.links.related}.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: multiple_import_entry_resources.to_h.to_json, status: response_status, headers: default_headers
         end
+
         let(:multiple_import_entry_resources) { build(:import_entries_from_fixture) }
+
         it "should return a list of import_entries" do
           subject.import_entries.tap do |import_entries|
             expect(import_entries.length).to eql multiple_import_entry_resources.data.length
@@ -37,6 +44,7 @@ RSpec.describe FlexCommerce::Import do
             end
           end
         end
+
         it "should return a list of import_entries with the correct attributes" do
           subject.import_entries.tap do |import_entries|
             expect(import_entries.length).to eql multiple_import_entry_resources.data.length
@@ -50,6 +58,7 @@ RSpec.describe FlexCommerce::Import do
         end
       end
     end
+
     context "working with multiple import_entry trees" do
       let(:resource_list) { build(:imports_from_fixture) }
       let(:quantity) { 2 }
@@ -57,9 +66,11 @@ RSpec.describe FlexCommerce::Import do
       let(:current_page) { nil }
       let(:expected_list_quantity) { 2 }
       subject { subject_class.all }
+
       before :each do
         stub_request(:get, "#{api_root}/imports.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: resource_list.to_h.to_json, status: response_status, headers: default_headers
       end
+
       it_should_behave_like "a collection of anything"
       it_should_behave_like "a collection of resources with an error response"
     end


### PR DESCRIPTION
### The issue #147 

The import models don't currently exist. This PR adds them so they can be used to complete this PR - https://github.com/shiftcommerce/flex-platform/issues/6957 - Import entries are not multi-tenanted so any account could access another accounts entries.

### The fix

Create the models with the correct associations. Nest import entries behind imports, which are multi-tenanted. This will be needed for this platform ticket to be completed https://github.com/shiftcommerce/flex-platform/issues/6957