### PR TITLE
Improve server error handling

### DIFF
--- a/lib/flex_commerce_api/error/internal_server.rb
+++ b/lib/flex_commerce_api/error/internal_server.rb
@@ -3,7 +3,7 @@ module FlexCommerceApi
     class InternalServer < Base
       def message
         body = response_env.fetch(:body, {"errors" => []})
-        error = body.is_a?(::String) ? body : body["errors"].first
+        error = extract_error(body)
         return "Internal server error" unless error.present?
         if error.is_a?(::Enumerable)
           title = error.fetch("title", "")
@@ -18,6 +18,12 @@ module FlexCommerceApi
         end
       end
 
+      private
+
+      def extract_error(body)
+        return body if body.is_a?(::String)
+        body["message"] || body["errors"].first
+      end
     end
   end
 end

--- a/lib/flex_commerce_api/error/internal_server.rb
+++ b/lib/flex_commerce_api/error/internal_server.rb
@@ -22,7 +22,7 @@ module FlexCommerceApi
 
       def extract_error(body)
         return body if body.is_a?(::String)
-        body["message"] || body["errors"].first
+        body["message"] || body["errors"]&.first
       end
     end
   end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,3 +1,3 @@
 module FlexCommerceApi
-  VERSION = '0.6.45'
+  VERSION = '0.6.46'
 end

--- a/spec/lib/flex_commerce_api/error/internal_server_spec.rb
+++ b/spec/lib/flex_commerce_api/error/internal_server_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe FlexCommerceApi::Error::InternalServer do
+  describe "message" do
+    it "extracts the error message for a string string body" do
+      response = {body: "oops!"}
+      internal_server_error = described_class.new(nil, response)
+      expect(internal_server_error.message).to eq "Internal server error - oops!"
+    end
+
+    it "extracts the error message from the 'message' field when given" do
+      response = {
+        body: {
+          "message" => "oops!"
+        }
+      }
+      internal_server_error = described_class.new(nil, response)
+      expect(internal_server_error.message).to eq "Internal server error - oops!"
+    end
+
+    it "extracts the error message for an errors hash" do
+      response = {
+        body: {
+          "errors" => [
+            "title" => "Oops!",
+            "detail" => "I have no idea what I am doing!",
+            "meta" => {
+              "exception" => "Exception details",
+              "backtrace" => "Exception backtrace",
+              "event_id" => "123"
+            }
+          ]
+        }
+      }
+      internal_server_error = described_class.new(nil, response)
+      expect(internal_server_error.message).to eq "Internal server error - Oops! I have no idea what I am doing! 123 Exception details Exception backtrace"
+    end
+
+    it "does not return an error message when there isn't one" do
+      response = {}
+      internal_server_error = described_class.new(nil, response)
+      expect(internal_server_error.message).to eq "Internal server error"
+    end
+
+  end
+end

--- a/spec/lib/flex_commerce_api/error/internal_server_spec.rb
+++ b/spec/lib/flex_commerce_api/error/internal_server_spec.rb
@@ -41,6 +41,5 @@ describe FlexCommerceApi::Error::InternalServer do
       internal_server_error = described_class.new(nil, response)
       expect(internal_server_error.message).to eq "Internal server error"
     end
-
   end
 end


### PR DESCRIPTION
When the back-end responds with a 500 error and the body of the following format:
```
{"message": "Internal server error"}
```
the gem is unable to form a proper error message and throws `NoMethodError: undefined method 'first' for nil:NilClass`. This makes debugging of the actual back-end response more difficult, see https://sentry.io/shift-commerce/matalan/issues/552886095/events/23884250449/ for an example.

This PR updates the gem so that it is able to correctly process responses like the one above and adds some tests coverage around this area. 