### PR TITLE
Allow new fields on create and update

### DIFF
--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,3 +1,3 @@
 module FlexCommerceApi
-  VERSION = '0.6.46'
+  VERSION = '0.6.47'
 end

--- a/lib/patches/json_api_client/resource.rb
+++ b/lib/patches/json_api_client/resource.rb
@@ -26,9 +26,12 @@ if ["1.1.1"].include?(JsonApiClient::VERSION)
           mark_as_persisted!
           if updated = last_result_set.first
             self.attributes = updated.attributes
+            # This line has been added as part of https://github.com/chingor13/json_api_client/pull/238
             self.links.attributes = updated.links.attributes
             self.relationships.attributes = updated.relationships.attributes
             clear_changes_information
+            # This line has been added as part of https://github.com/JsonApiClient/json_api_client/pull/285
+            self.relationships.clear_changes_information
           end
           true
         end
@@ -36,5 +39,12 @@ if ["1.1.1"].include?(JsonApiClient::VERSION)
     end
   end
 else
-  raise "Please check this PR (https://github.com/chingor13/json_api_client/pull/238) and if it has been merged, remove this file (#{__FILE__}) - if not add the current version to the allowed array at the top of this file."
+  raise %q(
+    Please check these two PRs:
+      * https://github.com/chingor13/json_api_client/pull/238 (This was released in version 1.5.0)
+      * https://github.com/JsonApiClient/json_api_client/pull/285 (This hasn't yet been released at the time of writing this)
+
+    If both have been merged into the gem version you are using, remove this file (#{__FILE__}).
+    If not, add the current version to the allowed array at the top of this file.
+  )
 end


### PR DESCRIPTION
Adds the ability to receive includes which have not been present on a resource when creating and updating.

This PR copies a change made to json_api_client gem in https://github.com/JsonApiClient/json_api_client/pull/285 which has already been merged into master but not released as a stable release yet.