### PR TITLE
Update gem version to v0.6.51

### DIFF
--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,3 +1,3 @@
 module FlexCommerceApi
-  VERSION = '0.6.50'
+  VERSION = '0.6.51'
 end


### PR DESCRIPTION
This long and unwieldy PR bumps the version from v0.6.50 to v0.6.51 (didn't do this as part of my last PR)