### PR TITLE
Added v1 deallocate order spec

### DIFF
--- a/app/models/deallocate_order.rb
+++ b/app/models/deallocate_order.rb
@@ -1,0 +1,8 @@
+require "flex_commerce_api/api_base"
+module FlexCommerce
+  class DeallocateOrder < FlexCommerceApi::ApiBase
+    def self.table_name
+      "deallocate_order"
+    end
+  end
+end

--- a/lib/flex_commerce.rb
+++ b/lib/flex_commerce.rb
@@ -32,6 +32,7 @@ module FlexCommerce
   autoload :DataAttribute, File.join(gem_root, "app", "models", "data_attribute")
   autoload :DataStoreRecord, File.join(gem_root, "app", "models", "data_store_record")
   autoload :DataStoreType, File.join(gem_root, "app", "models", "data_store_type")
+  autoload :DeallocateOrder, File.join(gem_root, "app", "models", "deallocate_order")
   autoload :DiscountSummary, File.join(gem_root, "app", "models", "discount_summary")
   autoload :Email, File.join(gem_root, "app", "models", "email")
   autoload :EwisOptIn, File.join(gem_root, "app", "models", "ewis_opt_in")

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,3 +1,3 @@
 module FlexCommerceApi
-  VERSION = "0.8.3"
+  VERSION = "0.8.4"
 end

--- a/spec/integration/deallocate_order_spec.rb
+++ b/spec/integration/deallocate_order_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "flex_commerce_api"
+require "uri"
+
+RSpec.describe FlexCommerce::DeallocateOrder do
+  # Global context for all specs - defines things you dont see defined in here
+  # such as flex_root_url, api_root, default_headers and page_size
+  # see api_globals.rb in spec/support for the source code
+  include_context "global context"
+
+  subject { described_class.create(order_id: 1) }
+
+  let(:headers) do 
+    { 
+      "Accept" => "application/vnd.api+json",
+      "Content-Type" => "application/vnd.api+json"}
+    }
+  end
+
+  context "when deallocating an order" do
+    before do
+      FlexCommerceApi.config.order_test_mode = false
+
+      request_body = {
+        data: {
+          type: "deallocate_order",
+          attributes: {
+            order_id: 1
+          }
+        }
+      }.to_json
+
+      stub_request(:post, "#{api_root}/deallocate_order.json_api")
+        .with(headers: headers, body: request_body)
+        .to_return do |request|
+        {
+          status: 201,
+          headers: headers,
+          body: {
+            data: {
+              id: "1",
+              type: "deallocate_order",
+              attributes: {
+                order_id: 1
+              }
+            }
+          }.to_json
+        }
+      end
+    end
+
+    it { is_expected.to be_a(described_class) }
+    it { is_expected.to have(0).errors }
+
+    # it "does not return errors" do
+    #   expect(subject).to be_a described_class
+    #   expect(subject.errors).to be_empty
+    # end
+  end
+end


### PR DESCRIPTION
In order to test deallocating orders via the v1 api, the ruby client needs to be extended.